### PR TITLE
Import keys improvements

### DIFF
--- a/core/src/main/kotlin/app/dapk/st/core/HeliumLogger.kt
+++ b/core/src/main/kotlin/app/dapk/st/core/HeliumLogger.kt
@@ -1,5 +1,9 @@
 package app.dapk.st.core
 
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onStart
+
 enum class AppLogTag(val key: String) {
     NOTIFICATION("notification"),
     PERFORMANCE("performance"),
@@ -25,4 +29,14 @@ suspend fun <T> logP(area: String, block: suspend () -> T): T {
         val timeTaken = System.currentTimeMillis() - start
         log(AppLogTag.PERFORMANCE, "$area: took $timeTaken ms")
     }
+}
+
+fun <T> Flow<T>.logP(area: String): Flow<T> {
+    var start = -1L
+    return this
+        .onStart { start = System.currentTimeMillis() }
+        .onCompletion {
+            val timeTaken = System.currentTimeMillis() - start
+            log(AppLogTag.PERFORMANCE, "$area: took $timeTaken ms")
+        }
 }

--- a/core/src/main/kotlin/app/dapk/st/core/Lce.kt
+++ b/core/src/main/kotlin/app/dapk/st/core/Lce.kt
@@ -6,3 +6,9 @@ sealed interface Lce<T> {
     data class Content<T>(val value: T) : Lce<T>
 }
 
+sealed interface LceWithProgress<T> {
+    data class Loading<T>(val progress: T) : LceWithProgress<T>
+    data class Error<T>(val cause: Throwable) : LceWithProgress<T>
+    data class Content<T>(val value: T) : LceWithProgress<T>
+}
+

--- a/domains/olm/src/main/kotlin/app/dapk/st/olm/OlmPersistenceWrapper.kt
+++ b/domains/olm/src/main/kotlin/app/dapk/st/olm/OlmPersistenceWrapper.kt
@@ -47,6 +47,10 @@ class OlmPersistenceWrapper(
         olmPersistence.persist(sessionId, SerializedObject(inboundGroupSession.serialize()))
     }
 
+    override suspend fun transaction(action: suspend () -> Unit) {
+        olmPersistence.startTransaction { action() }
+    }
+
     override suspend fun readInbound(sessionId: SessionId): OlmInboundGroupSession? {
         return olmPersistence.readInbound(sessionId)?.value?.deserialize()
     }

--- a/domains/olm/src/main/kotlin/app/dapk/st/olm/OlmStore.kt
+++ b/domains/olm/src/main/kotlin/app/dapk/st/olm/OlmStore.kt
@@ -12,6 +12,7 @@ interface OlmStore {
     suspend fun read(): OlmAccount?
     suspend fun persist(olmAccount: OlmAccount)
 
+    suspend fun transaction(action: suspend () -> Unit)
     suspend fun readOutbound(roomId: RoomId): Pair<Long, OlmOutboundGroupSession>?
     suspend fun persistOutbound(roomId: RoomId, creationTimestampUtc: Long, outboundGroupSession: OlmOutboundGroupSession)
     suspend fun persistSession(identity: Curve25519, sessionId: SessionId, olmSession: OlmSession)

--- a/domains/olm/src/main/kotlin/app/dapk/st/olm/OlmWrapper.kt
+++ b/domains/olm/src/main/kotlin/app/dapk/st/olm/OlmWrapper.kt
@@ -46,13 +46,16 @@ class OlmWrapper(
 
     override suspend fun import(keys: List<SharedRoomKey>) {
         interactWithOlm()
-        keys.forEach {
-            val inBound = when (it.isExported) {
-                true -> OlmInboundGroupSession.importSession(it.sessionKey)
-                false -> OlmInboundGroupSession(it.sessionKey)
+
+        olmStore.transaction {
+            keys.forEach {
+                val inBound = when (it.isExported) {
+                    true -> OlmInboundGroupSession.importSession(it.sessionKey)
+                    false -> OlmInboundGroupSession(it.sessionKey)
+                }
+                logger.crypto("import megolm ${it.sessionKey}")
+                olmStore.persist(it.sessionId, inBound)
             }
-            logger.crypto("import megolm ${it.sessionKey}")
-            olmStore.persist(it.sessionId, inBound)
         }
     }
 

--- a/domains/olm/src/main/kotlin/app/dapk/st/olm/OlmWrapper.kt
+++ b/domains/olm/src/main/kotlin/app/dapk/st/olm/OlmWrapper.kt
@@ -53,7 +53,6 @@ class OlmWrapper(
                     true -> OlmInboundGroupSession.importSession(it.sessionKey)
                     false -> OlmInboundGroupSession(it.sessionKey)
                 }
-                logger.crypto("import megolm ${it.sessionKey}")
                 olmStore.persist(it.sessionId, inBound)
             }
         }

--- a/domains/store/src/main/kotlin/app/dapk/st/domain/OlmPersistence.kt
+++ b/domains/store/src/main/kotlin/app/dapk/st/domain/OlmPersistence.kt
@@ -4,79 +4,113 @@ import app.dapk.db.DapkDb
 import app.dapk.db.model.DbCryptoAccount
 import app.dapk.db.model.DbCryptoMegolmInbound
 import app.dapk.db.model.DbCryptoMegolmOutbound
+import app.dapk.st.core.CoroutineDispatchers
+import app.dapk.st.core.withIoContext
 import app.dapk.st.matrix.common.CredentialsStore
 import app.dapk.st.matrix.common.Curve25519
 import app.dapk.st.matrix.common.RoomId
 import app.dapk.st.matrix.common.SessionId
+import com.squareup.sqldelight.TransactionWithoutReturn
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
 
 class OlmPersistence(
     private val database: DapkDb,
     private val credentialsStore: CredentialsStore,
+    private val dispatchers: CoroutineDispatchers,
 ) {
 
     suspend fun read(): String? {
-        return database.cryptoQueries
-            .selectAccount(credentialsStore.credentials()!!.userId.value)
-            .executeAsOneOrNull()
+        return dispatchers.withIoContext {
+            database.cryptoQueries
+                .selectAccount(credentialsStore.credentials()!!.userId.value)
+                .executeAsOneOrNull()
+        }
     }
 
     suspend fun persist(olmAccount: SerializedObject) {
-        database.cryptoQueries.insertAccount(
-            DbCryptoAccount(
-                user_id = credentialsStore.credentials()!!.userId.value,
-                blob = olmAccount.value
+        dispatchers.withIoContext {
+            database.cryptoQueries.insertAccount(
+                DbCryptoAccount(
+                    user_id = credentialsStore.credentials()!!.userId.value,
+                    blob = olmAccount.value
+                )
             )
-        )
+        }
     }
 
     suspend fun readOutbound(roomId: RoomId): Pair<Long, String>? {
-        return database.cryptoQueries
-            .selectMegolmOutbound(roomId.value)
-            .executeAsOneOrNull()?.let {
-                it.utcEpochMillis to it.blob
-            }
+        return dispatchers.withIoContext {
+            database.cryptoQueries
+                .selectMegolmOutbound(roomId.value)
+                .executeAsOneOrNull()?.let {
+                    it.utcEpochMillis to it.blob
+                }
+        }
     }
 
     suspend fun persistOutbound(roomId: RoomId, creationTimestampUtc: Long, outboundGroupSession: SerializedObject) {
-        database.cryptoQueries.insertMegolmOutbound(
-            DbCryptoMegolmOutbound(
-                room_id = roomId.value,
-                blob = outboundGroupSession.value,
-                utcEpochMillis = creationTimestampUtc,
+        dispatchers.withIoContext {
+            database.cryptoQueries.insertMegolmOutbound(
+                DbCryptoMegolmOutbound(
+                    room_id = roomId.value,
+                    blob = outboundGroupSession.value,
+                    utcEpochMillis = creationTimestampUtc,
+                )
             )
-        )
+        }
     }
 
     suspend fun persistSession(identity: Curve25519, sessionId: SessionId, olmSession: SerializedObject) {
-        database.cryptoQueries.insertOlmSession(
-            identity_key = identity.value,
-            session_id = sessionId.value,
-            blob = olmSession.value,
-        )
+        withContext(dispatchers.io) {
+            database.cryptoQueries.insertOlmSession(
+                identity_key = identity.value,
+                session_id = sessionId.value,
+                blob = olmSession.value,
+            )
+        }
     }
 
     suspend fun readSessions(identities: List<Curve25519>): List<Pair<Curve25519, String>>? {
-        return database.cryptoQueries
-            .selectOlmSession(identities.map { it.value })
-            .executeAsList()
-            .map { Curve25519(it.identity_key) to it.blob }
-            .takeIf { it.isNotEmpty() }
+        return withContext(dispatchers.io) {
+            database.cryptoQueries
+                .selectOlmSession(identities.map { it.value })
+                .executeAsList()
+                .map { Curve25519(it.identity_key) to it.blob }
+                .takeIf { it.isNotEmpty() }
+        }
+    }
+
+    suspend fun startTransaction(action: suspend TransactionWithoutReturn.() -> Unit) {
+        val transaction = suspendCoroutine {
+            database.cryptoQueries.transaction(false) {
+                it.resume(this)
+            }
+        }
+        dispatchers.withIoContext {
+            action(transaction)
+        }
     }
 
     suspend fun persist(sessionId: SessionId, inboundGroupSession: SerializedObject) {
-        database.cryptoQueries.insertMegolmInbound(
-            DbCryptoMegolmInbound(
-                session_id = sessionId.value,
-                blob = inboundGroupSession.value
+        withContext(dispatchers.io) {
+            database.cryptoQueries.insertMegolmInbound(
+                DbCryptoMegolmInbound(
+                    session_id = sessionId.value,
+                    blob = inboundGroupSession.value
+                )
             )
-        )
+        }
     }
 
     suspend fun readInbound(sessionId: SessionId): SerializedObject? {
-        return database.cryptoQueries
-            .selectMegolmInbound(sessionId.value)
-            .executeAsOneOrNull()
-            ?.let { SerializedObject((it)) }
+        return withContext(dispatchers.io) {
+            database.cryptoQueries
+                .selectMegolmInbound(sessionId.value)
+                .executeAsOneOrNull()
+                ?.let { SerializedObject((it)) }
+        }
     }
 
 }

--- a/domains/store/src/main/kotlin/app/dapk/st/domain/StoreModule.kt
+++ b/domains/store/src/main/kotlin/app/dapk/st/domain/StoreModule.kt
@@ -39,7 +39,7 @@ class StoreModule(
 
     fun applicationStore() = ApplicationPreferences(preferences)
 
-    fun olmStore() = OlmPersistence(database, credentialsStore())
+    fun olmStore() = OlmPersistence(database, credentialsStore(), coroutineDispatchers)
     fun knownDevicesStore() = DevicePersistence(database, KnownDevicesCache(), coroutineDispatchers)
 
     fun profileStore(): ProfileStore = ProfilePersistence(preferences)

--- a/domains/store/src/main/sqldelight/app/dapk/db/model/EventLogger.sq
+++ b/domains/store/src/main/sqldelight/app/dapk/db/model/EventLogger.sq
@@ -13,12 +13,14 @@ FROM dbEventLog;
 selectLatestByLog:
 SELECT id, tag, content, time(utcEpochSeconds,'unixepoch')
 FROM dbEventLog
-WHERE logParent = ?;
+WHERE logParent = ?
+ORDER BY utcEpochSeconds DESC;
 
 selectLatestByLogFiltered:
 SELECT id, tag, content, time(utcEpochSeconds,'unixepoch')
 FROM dbEventLog
-WHERE logParent = ? AND tag = ?;
+WHERE logParent = ? AND tag = ?
+ORDER BY utcEpochSeconds DESC;
 
 insert:
 INSERT INTO dbEventLog(tag, content, utcEpochSeconds, logParent)

--- a/features/settings/src/main/kotlin/app/dapk/st/settings/SettingsScreen.kt
+++ b/features/settings/src/main/kotlin/app/dapk/st/settings/SettingsScreen.kt
@@ -44,6 +44,7 @@ import app.dapk.st.design.components.SettingsTextRow
 import app.dapk.st.design.components.Spider
 import app.dapk.st.design.components.SpiderPage
 import app.dapk.st.design.components.TextRow
+import app.dapk.st.matrix.crypto.ImportResult
 import app.dapk.st.navigator.Navigator
 import app.dapk.st.settings.SettingsEvent.*
 import app.dapk.st.settings.eventlogger.EventLogActivity
@@ -137,10 +138,10 @@ internal fun SettingsScreen(viewModel: SettingsViewModel, onSignOut: () -> Unit,
                     }
                 }
 
-                is LceWithProgress.Content -> {
+                is ImportResult.Success -> {
                     Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                         Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                            Text(text = "Successfully imported ${it.importProgress.value} keys")
+                            Text(text = "Successfully imported ${it.importProgress.totalImportedKeysCount} keys")
                             Spacer(modifier = Modifier.height(12.dp))
                             Button(onClick = { navigator.navigate.upToHome() }) {
                                 Text(text = "Close".uppercase())
@@ -149,7 +150,7 @@ internal fun SettingsScreen(viewModel: SettingsViewModel, onSignOut: () -> Unit,
                     }
                 }
 
-                is LceWithProgress.Error -> {
+                is ImportResult.Error -> {
                     Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                         Column(horizontalAlignment = Alignment.CenterHorizontally) {
                             Text(text = "Import failed")
@@ -160,10 +161,10 @@ internal fun SettingsScreen(viewModel: SettingsViewModel, onSignOut: () -> Unit,
                     }
                 }
 
-                is LceWithProgress.Loading -> {
+                is ImportResult.Update -> {
                     Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                         Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                            Text(text = "Imported ${it.importProgress.progress} keys")
+                            Text(text = "Imported ${it.importProgress.importedKeysCount} keys")
                             Spacer(modifier = Modifier.height(12.dp))
                             CircularProgressIndicator(Modifier.wrapContentSize())
                         }

--- a/features/settings/src/main/kotlin/app/dapk/st/settings/SettingsScreen.kt
+++ b/features/settings/src/main/kotlin/app/dapk/st/settings/SettingsScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.net.toUri
 import app.dapk.st.core.Lce
+import app.dapk.st.core.LceWithProgress
 import app.dapk.st.core.StartObserving
 import app.dapk.st.core.components.CenteredLoading
 import app.dapk.st.core.components.Header
@@ -136,10 +137,11 @@ internal fun SettingsScreen(viewModel: SettingsViewModel, onSignOut: () -> Unit,
                     }
                 }
 
-                is Lce.Content -> {
+                is LceWithProgress.Content -> {
                     Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                         Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                            Text(text = "Import success")
+                            Text(text = "Successfully imported ${it.importProgress.value} keys")
+                            Spacer(modifier = Modifier.height(12.dp))
                             Button(onClick = { navigator.navigate.upToHome() }) {
                                 Text(text = "Close".uppercase())
                             }
@@ -147,7 +149,7 @@ internal fun SettingsScreen(viewModel: SettingsViewModel, onSignOut: () -> Unit,
                     }
                 }
 
-                is Lce.Error -> {
+                is LceWithProgress.Error -> {
                     Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                         Column(horizontalAlignment = Alignment.CenterHorizontally) {
                             Text(text = "Import failed")
@@ -158,7 +160,15 @@ internal fun SettingsScreen(viewModel: SettingsViewModel, onSignOut: () -> Unit,
                     }
                 }
 
-                is Lce.Loading -> CenteredLoading()
+                is LceWithProgress.Loading -> {
+                    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Text(text = "Imported ${it.importProgress.progress} keys")
+                            Spacer(modifier = Modifier.height(12.dp))
+                            CircularProgressIndicator(Modifier.wrapContentSize())
+                        }
+                    }
+                }
             }
         }
     }

--- a/features/settings/src/main/kotlin/app/dapk/st/settings/SettingsScreen.kt
+++ b/features/settings/src/main/kotlin/app/dapk/st/settings/SettingsScreen.kt
@@ -158,6 +158,7 @@ internal fun SettingsScreen(viewModel: SettingsViewModel, onSignOut: () -> Unit,
                                 ImportResult.Error.Type.NoKeysFound -> "No keys found in the file"
                                 ImportResult.Error.Type.UnexpectedDecryptionOutput -> "Unable to decrypt file, double check your passphrase"
                                 is ImportResult.Error.Type.Unknown -> "${type.cause::class.java.simpleName}: ${type.cause.message}"
+                                ImportResult.Error.Type.UnableToOpenFile -> "Unable to open file"
                             }
 
                             Text(text = "Import failed\n$message", textAlign = TextAlign.Center)

--- a/features/settings/src/main/kotlin/app/dapk/st/settings/SettingsScreen.kt
+++ b/features/settings/src/main/kotlin/app/dapk/st/settings/SettingsScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -74,7 +75,7 @@ internal fun SettingsScreen(viewModel: SettingsViewModel, onSignOut: () -> Unit,
             PushProviders(viewModel, it)
         }
         item(Page.Routes.importRoomKeys) {
-            when (it.importProgress) {
+            when (val result = it.importProgress) {
                 null -> {
                     Box(
                         modifier = Modifier.fillMaxSize(),
@@ -141,7 +142,7 @@ internal fun SettingsScreen(viewModel: SettingsViewModel, onSignOut: () -> Unit,
                 is ImportResult.Success -> {
                     Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                         Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                            Text(text = "Successfully imported ${it.importProgress.totalImportedKeysCount} keys")
+                            Text(text = "Successfully imported ${result.totalImportedKeysCount} keys")
                             Spacer(modifier = Modifier.height(12.dp))
                             Button(onClick = { navigator.navigate.upToHome() }) {
                                 Text(text = "Close".uppercase())
@@ -153,7 +154,14 @@ internal fun SettingsScreen(viewModel: SettingsViewModel, onSignOut: () -> Unit,
                 is ImportResult.Error -> {
                     Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                         Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                            Text(text = "Import failed")
+                            val message = when(val type = result.cause) {
+                                ImportResult.Error.Type.NoKeysFound -> "No keys found in the file"
+                                ImportResult.Error.Type.UnexpectedDecryptionOutput -> "Unable to decrypt file, double check your passphrase"
+                                is ImportResult.Error.Type.Unknown -> "${type.cause::class.java.simpleName}: ${type.cause.message}"
+                            }
+
+                            Text(text = "Import failed\n$message", textAlign = TextAlign.Center)
+                            Spacer(modifier = Modifier.height(12.dp))
                             Button(onClick = { navigator.navigate.upToHome() }) {
                                 Text(text = "Close".uppercase())
                             }
@@ -164,7 +172,7 @@ internal fun SettingsScreen(viewModel: SettingsViewModel, onSignOut: () -> Unit,
                 is ImportResult.Update -> {
                     Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                         Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                            Text(text = "Imported ${it.importProgress.importedKeysCount} keys")
+                            Text(text = "Importing ${result.importedKeysCount} keys...")
                             Spacer(modifier = Modifier.height(12.dp))
                             CircularProgressIndicator(Modifier.wrapContentSize())
                         }

--- a/features/settings/src/main/kotlin/app/dapk/st/settings/SettingsState.kt
+++ b/features/settings/src/main/kotlin/app/dapk/st/settings/SettingsState.kt
@@ -5,6 +5,7 @@ import app.dapk.st.core.Lce
 import app.dapk.st.core.LceWithProgress
 import app.dapk.st.design.components.Route
 import app.dapk.st.design.components.SpiderPage
+import app.dapk.st.matrix.crypto.ImportResult
 import app.dapk.st.push.Registrar
 
 internal data class SettingsScreenState(
@@ -16,7 +17,7 @@ internal sealed interface Page {
     object Security : Page
     data class ImportRoomKey(
         val selectedFile: NamedUri? = null,
-        val importProgress: LceWithProgress<Long>? = null,
+        val importProgress: ImportResult? = null,
     ) : Page
 
     data class PushProviders(

--- a/features/settings/src/main/kotlin/app/dapk/st/settings/SettingsState.kt
+++ b/features/settings/src/main/kotlin/app/dapk/st/settings/SettingsState.kt
@@ -2,6 +2,7 @@ package app.dapk.st.settings
 
 import android.net.Uri
 import app.dapk.st.core.Lce
+import app.dapk.st.core.LceWithProgress
 import app.dapk.st.design.components.Route
 import app.dapk.st.design.components.SpiderPage
 import app.dapk.st.push.Registrar
@@ -15,7 +16,7 @@ internal sealed interface Page {
     object Security : Page
     data class ImportRoomKey(
         val selectedFile: NamedUri? = null,
-        val importProgress: Lce<Unit>? = null,
+        val importProgress: LceWithProgress<Long>? = null,
     ) : Page
 
     data class PushProviders(

--- a/features/settings/src/main/kotlin/app/dapk/st/settings/SettingsViewModel.kt
+++ b/features/settings/src/main/kotlin/app/dapk/st/settings/SettingsViewModel.kt
@@ -2,7 +2,6 @@ package app.dapk.st.settings
 
 import android.content.ContentResolver
 import android.net.Uri
-import android.util.Log
 import androidx.lifecycle.viewModelScope
 import app.dapk.st.core.Lce
 import app.dapk.st.core.LceWithProgress
@@ -125,21 +124,21 @@ internal class SettingsViewModel(
     }
 
     fun importFromFileKeys(file: Uri, passphrase: String) {
-        updatePageState<Page.ImportRoomKey> { copy(importProgress = LceWithProgress.Loading(0L)) }
+        updatePageState<Page.ImportRoomKey> { copy(importProgress = ImportResult.Update(0)) }
         viewModelScope.launch {
             with(cryptoService) {
                 contentResolver.openInputStream(file)?.importRoomKeys(passphrase)
                     ?.onEach {
+                        updatePageState<Page.ImportRoomKey> { copy(importProgress = it) }
                         when (it) {
                             is ImportResult.Error -> {
-                                updatePageState<Page.ImportRoomKey> { copy(importProgress = LceWithProgress.Error(it.cause)) }
+                                // do nothing
                             }
                             is ImportResult.Update -> {
-                                updatePageState<Page.ImportRoomKey> { copy(importProgress = LceWithProgress.Loading(it.importedKeysCount)) }
+                                // do nothing
                             }
                             is ImportResult.Success -> {
                                 syncService.forceManualRefresh(it.roomIds.toList())
-                                updatePageState<Page.ImportRoomKey> { copy(importProgress = LceWithProgress.Content(it.totalImportedKeysCount)) }
                             }
                         }
                     }

--- a/features/settings/src/main/kotlin/app/dapk/st/settings/SettingsViewModel.kt
+++ b/features/settings/src/main/kotlin/app/dapk/st/settings/SettingsViewModel.kt
@@ -2,11 +2,14 @@ package app.dapk.st.settings
 
 import android.content.ContentResolver
 import android.net.Uri
+import android.util.Log
 import androidx.lifecycle.viewModelScope
 import app.dapk.st.core.Lce
+import app.dapk.st.core.LceWithProgress
 import app.dapk.st.design.components.SpiderPage
 import app.dapk.st.domain.StoreCleaner
 import app.dapk.st.matrix.crypto.CryptoService
+import app.dapk.st.matrix.crypto.ImportResult
 import app.dapk.st.matrix.sync.SyncService
 import app.dapk.st.push.PushTokenRegistrars
 import app.dapk.st.push.Registrar
@@ -15,6 +18,8 @@ import app.dapk.st.settings.SettingsEvent.*
 import app.dapk.st.viewmodel.DapkViewModel
 import app.dapk.st.viewmodel.MutableStateFactory
 import app.dapk.st.viewmodel.defaultStateFactory
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 
 private const val PRIVACY_POLICY_URL = "https://ouchadam.github.io/small-talk/privacy/"
@@ -120,17 +125,26 @@ internal class SettingsViewModel(
     }
 
     fun importFromFileKeys(file: Uri, passphrase: String) {
-        updatePageState<Page.ImportRoomKey> { copy(importProgress = Lce.Loading()) }
+        updatePageState<Page.ImportRoomKey> { copy(importProgress = LceWithProgress.Loading(0L)) }
         viewModelScope.launch {
-            kotlin.runCatching {
-                with(cryptoService) {
-                    val roomsToRefresh = contentResolver.openInputStream(file)?.importRoomKeys(passphrase)
-                    roomsToRefresh?.let { syncService.forceManualRefresh(roomsToRefresh) }
-                }
-            }.fold(
-                onSuccess = { updatePageState<Page.ImportRoomKey> { copy(importProgress = Lce.Content(Unit)) } },
-                onFailure = { updatePageState<Page.ImportRoomKey> { copy(importProgress = Lce.Error(it)) } }
-            )
+            with(cryptoService) {
+                contentResolver.openInputStream(file)?.importRoomKeys(passphrase)
+                    ?.onEach {
+                        when (it) {
+                            is ImportResult.Error -> {
+                                updatePageState<Page.ImportRoomKey> { copy(importProgress = LceWithProgress.Error(it.cause)) }
+                            }
+                            is ImportResult.Update -> {
+                                updatePageState<Page.ImportRoomKey> { copy(importProgress = LceWithProgress.Loading(it.importedKeysCount)) }
+                            }
+                            is ImportResult.Success -> {
+                                syncService.forceManualRefresh(it.roomIds.toList())
+                                updatePageState<Page.ImportRoomKey> { copy(importProgress = LceWithProgress.Content(it.totalImportedKeysCount)) }
+                            }
+                        }
+                    }
+                    ?.launchIn(viewModelScope)
+            }
         }
     }
 

--- a/matrix/services/crypto/src/main/kotlin/app/dapk/st/matrix/crypto/CryptoService.kt
+++ b/matrix/services/crypto/src/main/kotlin/app/dapk/st/matrix/crypto/CryptoService.kt
@@ -18,7 +18,7 @@ interface CryptoService : MatrixService {
     suspend fun encrypt(roomId: RoomId, credentials: DeviceCredentials, messageJson: JsonString): Crypto.EncryptionResult
     suspend fun decrypt(encryptedPayload: EncryptedMessageContent): DecryptionResult
     suspend fun importRoomKeys(keys: List<SharedRoomKey>)
-    suspend fun InputStream.importRoomKeys(password: String): List<RoomId>
+    suspend fun InputStream.importRoomKeys(password: String): Flow<ImportResult>
 
     suspend fun maybeCreateMoreKeys(serverKeyCount: ServerKeyCount)
     suspend fun updateOlmSession(userIds: List<UserId>, syncToken: SyncToken?)
@@ -159,4 +159,10 @@ fun MatrixServiceProvider.cryptoService(): CryptoService = this.getService(key =
 
 fun interface RoomMembersProvider {
     suspend fun userIdsForRoom(roomId: RoomId): List<UserId>
+}
+
+sealed interface ImportResult {
+    data class Success(val roomIds: Set<RoomId>, val totalImportedKeysCount: Long) : ImportResult
+    data class Error(val cause: Throwable) : ImportResult
+    data class Update(val importedKeysCount: Long) : ImportResult
 }

--- a/matrix/services/crypto/src/main/kotlin/app/dapk/st/matrix/crypto/CryptoService.kt
+++ b/matrix/services/crypto/src/main/kotlin/app/dapk/st/matrix/crypto/CryptoService.kt
@@ -169,6 +169,7 @@ sealed interface ImportResult {
             data class Unknown(val cause: Throwable): Type
             object NoKeysFound: Type
             object UnexpectedDecryptionOutput: Type
+            object UnableToOpenFile: Type
         }
 
     }

--- a/matrix/services/crypto/src/main/kotlin/app/dapk/st/matrix/crypto/CryptoService.kt
+++ b/matrix/services/crypto/src/main/kotlin/app/dapk/st/matrix/crypto/CryptoService.kt
@@ -163,6 +163,14 @@ fun interface RoomMembersProvider {
 
 sealed interface ImportResult {
     data class Success(val roomIds: Set<RoomId>, val totalImportedKeysCount: Long) : ImportResult
-    data class Error(val cause: Throwable) : ImportResult
+    data class Error(val cause: Type) : ImportResult {
+
+        sealed interface Type {
+            data class Unknown(val cause: Throwable): Type
+            object NoKeysFound: Type
+            object UnexpectedDecryptionOutput: Type
+        }
+
+    }
     data class Update(val importedKeysCount: Long) : ImportResult
 }

--- a/matrix/services/crypto/src/main/kotlin/app/dapk/st/matrix/crypto/internal/DefaultCryptoService.kt
+++ b/matrix/services/crypto/src/main/kotlin/app/dapk/st/matrix/crypto/internal/DefaultCryptoService.kt
@@ -1,5 +1,6 @@
 package app.dapk.st.matrix.crypto.internal
 
+import app.dapk.st.core.logP
 import app.dapk.st.matrix.common.*
 import app.dapk.st.matrix.crypto.Crypto
 import app.dapk.st.matrix.crypto.CryptoService
@@ -48,8 +49,12 @@ internal class DefaultCryptoService(
     }
 
     override suspend fun InputStream.importRoomKeys(password: String): List<RoomId> {
-        return with(roomKeyImporter) {
-            importRoomKeys(password) { importRoomKeys(it) }
+        return logP("import room keys") {
+            with(roomKeyImporter) {
+                importRoomKeys(password) {
+                    importRoomKeys(it)
+                }
+            }
         }
     }
 }

--- a/matrix/services/crypto/src/main/kotlin/app/dapk/st/matrix/crypto/internal/DefaultCryptoService.kt
+++ b/matrix/services/crypto/src/main/kotlin/app/dapk/st/matrix/crypto/internal/DefaultCryptoService.kt
@@ -50,12 +50,10 @@ internal class DefaultCryptoService(
     }
 
     override suspend fun InputStream.importRoomKeys(password: String): Flow<ImportResult> {
-        return logP("import room keys") {
-            with(roomKeyImporter) {
-                importRoomKeys(password) {
-                    importRoomKeys(it)
-                }
-            }
+        return with(roomKeyImporter) {
+            importRoomKeys(password) {
+                importRoomKeys(it)
+            }.logP("import room keys")
         }
     }
 }

--- a/matrix/services/crypto/src/main/kotlin/app/dapk/st/matrix/crypto/internal/DefaultCryptoService.kt
+++ b/matrix/services/crypto/src/main/kotlin/app/dapk/st/matrix/crypto/internal/DefaultCryptoService.kt
@@ -4,6 +4,7 @@ import app.dapk.st.core.logP
 import app.dapk.st.matrix.common.*
 import app.dapk.st.matrix.crypto.Crypto
 import app.dapk.st.matrix.crypto.CryptoService
+import app.dapk.st.matrix.crypto.ImportResult
 import app.dapk.st.matrix.crypto.Verification
 import kotlinx.coroutines.flow.Flow
 import java.io.InputStream
@@ -48,7 +49,7 @@ internal class DefaultCryptoService(
         verificationHandler.onUserVerificationAction(verificationAction)
     }
 
-    override suspend fun InputStream.importRoomKeys(password: String): List<RoomId> {
+    override suspend fun InputStream.importRoomKeys(password: String): Flow<ImportResult> {
         return logP("import room keys") {
             with(roomKeyImporter) {
                 importRoomKeys(password) {

--- a/matrix/services/crypto/src/main/kotlin/app/dapk/st/matrix/crypto/internal/OlmCrypto.kt
+++ b/matrix/services/crypto/src/main/kotlin/app/dapk/st/matrix/crypto/internal/OlmCrypto.kt
@@ -14,7 +14,6 @@ internal class OlmCrypto(
 ) {
 
     suspend fun importRoomKeys(keys: List<SharedRoomKey>) {
-        logger.crypto("import room keys : ${keys.size}")
         olm.import(keys)
     }
 

--- a/matrix/services/crypto/src/main/kotlin/app/dapk/st/matrix/crypto/internal/RoomKeyImporter.kt
+++ b/matrix/services/crypto/src/main/kotlin/app/dapk/st/matrix/crypto/internal/RoomKeyImporter.kt
@@ -86,7 +86,7 @@ class RoomKeyImporter(
                                 isExported = true,
                             )
                         }
-                        .chunked(50)
+                        .chunked(500)
                         .forEach { onChunk(it) }
                 }
                 roomIds.toList().ifEmpty {

--- a/test-harness/src/test/kotlin/SmokeTest.kt
+++ b/test-harness/src/test/kotlin/SmokeTest.kt
@@ -4,11 +4,13 @@ import app.dapk.st.matrix.common.HomeServerUrl
 import app.dapk.st.matrix.common.RoomId
 import app.dapk.st.matrix.common.RoomMember
 import app.dapk.st.matrix.common.UserId
+import app.dapk.st.matrix.crypto.ImportResult
 import app.dapk.st.matrix.crypto.Verification
 import app.dapk.st.matrix.crypto.cryptoService
 import app.dapk.st.matrix.room.roomService
 import app.dapk.st.matrix.sync.syncService
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.shouldBeEqualTo
@@ -97,10 +99,13 @@ class SmokeTest {
         val stream = loadResourceStream("element-keys.txt")
 
         val result = with(cryptoService) {
-            stream.importRoomKeys(password = "aaaaaa")
+            stream.importRoomKeys(password = "aaaaaa").first { it is ImportResult.Success }
         }
 
-        result shouldBeEqualTo listOf(RoomId(value = "!qOSENTtFUuCEKJSVzl:matrix.org"))
+        result shouldBeEqualTo ImportResult.Success(
+            roomIds = setOf(RoomId(value = "!qOSENTtFUuCEKJSVzl:matrix.org")),
+            totalImportedKeysCount = 28,
+        )
     }
 
     private fun testTextMessaging(isEncrypted: Boolean) = testAfterInitialSync { alice, bob ->

--- a/tools/beta-release/app.js
+++ b/tools/beta-release/app.js
@@ -150,7 +150,6 @@ const incrementVersionFile = async (github, branchName) => {
         name: updatedVersionName,
     }
 
-
     const encodedContentUpdate = Buffer.from(JSON.stringify(updatedVersionFile, null, 2)).toString('base64')
     await github.rest.repos.createOrUpdateFileContents({
         owner: config.owner,


### PR DESCRIPTION
- Improves key import performance (a 30mb file with 36k keys previously took 140 seconds, with this PR it ranges between 35s and 55s)
- Adds error messaging to help clarify the cause of any failures
- Adds in progress updates to show the import is _doing something_
- Inverts the log screen to order by most recent logs first