### PR TITLE
Ensure FOSS build has no firebase dependencies

### DIFF
--- a/features/notifications/build.gradle
+++ b/features/notifications/build.gradle
@@ -12,8 +12,6 @@ dependencies {
     implementation project(":features:messenger")
     implementation project(":features:navigator")
 
-    implementation platform('com.google.firebase:firebase-bom:29.0.3')
-    implementation 'com.google.firebase:firebase-messaging'
     implementation Dependencies.mavenCentral.kotlinSerializationJson
 
     kotlinTest(it)

--- a/features/notifications/src/main/kotlin/app/dapk/st/notifications/AndroidNotificationStyle.kt
+++ b/features/notifications/src/main/kotlin/app/dapk/st/notifications/AndroidNotificationStyle.kt
@@ -2,8 +2,6 @@ package app.dapk.st.notifications
 
 import android.app.Notification
 import android.graphics.drawable.Icon
-import android.os.Build
-import androidx.annotation.RequiresApi
 
 sealed interface AndroidNotificationStyle {
 
@@ -20,7 +18,6 @@ sealed interface AndroidNotificationStyle {
         val content: List<AndroidMessage>,
     ) : AndroidNotificationStyle {
 
-        @RequiresApi(Build.VERSION_CODES.P)
         override fun build(builder: AndroidNotificationStyleBuilder) = builder.build(this)
 
         data class AndroidPerson(val name: String, val key: String, val icon: Icon? = null)

--- a/features/notifications/src/main/kotlin/app/dapk/st/notifications/AndroidNotificationStyleBuilder.kt
+++ b/features/notifications/src/main/kotlin/app/dapk/st/notifications/AndroidNotificationStyleBuilder.kt
@@ -5,8 +5,6 @@ import android.app.Notification
 import android.app.Notification.InboxStyle
 import android.app.Notification.MessagingStyle
 import android.app.Person
-import android.os.Build
-import androidx.annotation.RequiresApi
 
 @SuppressLint("NewApi")
 class AndroidNotificationStyleBuilder(
@@ -27,7 +25,6 @@ class AndroidNotificationStyleBuilder(
         inboxStyle.setSummaryText(summary)
     }
 
-    @RequiresApi(Build.VERSION_CODES.P)
     private fun AndroidNotificationStyle.Messaging.buildMessagingStyle() = messagingStyleFactory(
         personBuilderFactory()
             .setName(person.name)


### PR DESCRIPTION
Fixes the `-Pfoss` not completely removing firebase references
 
- The notification module was pulling in `firebase` for an annotation import, which in turn pulled in the .aar manifest entries and services etc, fixed by removing the unneeded dependency


firebase references in the decompiled output before and after the change

```
apktool d universal.apk -o out --force && grep -r 'firebase' out/ | wc -l
> 302

apktool d before-foss.apk -o out --force && grep -r 'firebase' out/ | wc -l
> 255

apktool d after-foss.apk -o out --force && grep -r 'firebase' out/ | wc -l
> 0
```

