### PR TITLE
Fixing synapse caching breaking encrypted smoke test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Create pip requirements
         run: |
-          echo "matrix-synapse==v1.60.0" > requirements.txt
+          echo "matrix-synapse" > requirements.txt
 
       - name: Set up Python 3.8
         uses: actions/setup-python@v2

--- a/domains/olm/src/main/kotlin/app/dapk/st/olm/OlmExtensions.kt
+++ b/domains/olm/src/main/kotlin/app/dapk/st/olm/OlmExtensions.kt
@@ -8,3 +8,7 @@ fun OlmAccount.readIdentityKeys(): Pair<Ed25519, Curve25519> {
     val identityKeys = this.identityKeys()
     return Ed25519(identityKeys["ed25519"]!!) to Curve25519(identityKeys["curve25519"]!!)
 }
+
+fun OlmAccount.oneTimeCurveKeys(): List<Pair<String, Curve25519>> {
+    return this.oneTimeKeys()["curve25519"]?.map { it.key to Curve25519(it.value) } ?: emptyList()
+}

--- a/matrix/services/crypto/src/main/kotlin/app/dapk/st/matrix/crypto/Olm.kt
+++ b/matrix/services/crypto/src/main/kotlin/app/dapk/st/matrix/crypto/Olm.kt
@@ -72,6 +72,7 @@ interface Olm {
         val fingerprint: Ed25519,
         val senderKey: Curve25519,
         val deviceKeys: DeviceKeys,
+        val hasKeys: Boolean,
         val maxKeys: Int,
         val olmAccount: Any,
     )

--- a/matrix/services/crypto/src/testFixtures/kotlin/fixture/CryptoSessionFixtures.kt
+++ b/matrix/services/crypto/src/testFixtures/kotlin/fixture/CryptoSessionFixtures.kt
@@ -10,8 +10,9 @@ fun anAccountCryptoSession(
     senderKey: Curve25519 = aCurve25519(),
     deviceKeys: DeviceKeys = aDeviceKeys(),
     maxKeys: Int = 5,
+    hasKeys: Boolean = false,
     olmAccount: Any = mockk(),
-) = Olm.AccountCryptoSession(fingerprint, senderKey, deviceKeys, maxKeys, olmAccount)
+) = Olm.AccountCryptoSession(fingerprint, senderKey, deviceKeys, hasKeys, maxKeys, olmAccount)
 
 fun aRoomCryptoSession(
     creationTimestampUtc: Long = 0L,

--- a/matrix/services/sync/src/main/kotlin/app/dapk/st/matrix/sync/internal/room/SyncSideEffects.kt
+++ b/matrix/services/sync/src/main/kotlin/app/dapk/st/matrix/sync/internal/room/SyncSideEffects.kt
@@ -27,6 +27,7 @@ internal class SyncSideEffects(
             response.deviceLists?.changed?.ifEmpty { null }?.let {
                 notifyDevicesUpdated.notifyChanges(it, requestToken)
             }
+
             oneTimeKeyProducer.onServerKeyCount(response.oneTimeKeysCount["signed_curve25519"] ?: ServerKeyCount(0))
 
             val decryptedToDeviceEvents = decryptedToDeviceEvents(response)

--- a/test-harness/src/test/kotlin/test/Test.kt
+++ b/test-harness/src/test/kotlin/test/Test.kt
@@ -5,17 +5,13 @@ package test
 import TestMessage
 import TestUser
 import app.dapk.st.core.extensions.ifNull
-import app.dapk.st.matrix.common.MxUrl
 import app.dapk.st.matrix.common.RoomId
 import app.dapk.st.matrix.common.RoomMember
-import app.dapk.st.matrix.common.convertMxUrToUrl
-import app.dapk.st.matrix.http.MatrixHttpClient
 import app.dapk.st.matrix.message.MessageService
 import app.dapk.st.matrix.message.messageService
 import app.dapk.st.matrix.sync.RoomEvent
 import app.dapk.st.matrix.sync.syncService
 import io.ktor.client.*
-import io.ktor.client.call.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.util.cio.*
@@ -28,7 +24,6 @@ import org.amshove.kluent.fail
 import org.amshove.kluent.shouldBeEqualTo
 import java.io.File
 import java.math.BigInteger
-import java.net.URL
 import java.security.MessageDigest
 import java.util.*
 

--- a/test-harness/src/test/kotlin/test/TestMatrix.kt
+++ b/test-harness/src/test/kotlin/test/TestMatrix.kt
@@ -46,6 +46,12 @@ import java.io.File
 import java.time.Clock
 import javax.imageio.ImageIO
 
+object TestUsers {
+
+    val users = mutableSetOf<TestUser>()
+
+}
+
 class TestMatrix(
     private val user: TestUser,
     temporaryDatabase: Boolean = false,
@@ -53,10 +59,11 @@ class TestMatrix(
     includeLogging: Boolean = false,
 ) {
 
-    private val errorTracker = PrintingErrorTracking(prefix = user.roomMember.id.value.split(":")[0])
+    private val errorTracker = PrintingErrorTracking(prefix = user.testName)
     private val logger: MatrixLogger = { tag, message ->
         if (includeLogging) {
-            println("${user.roomMember.id.value.split(":")[0]}  $tag $message")
+            val messageWithIdReplaceByName = TestUsers.users.fold(message) { acc, user -> acc.replace(user.roomMember.id.value, "*${user.testName}") }
+            println("${user.testName}  $tag $messageWithIdReplaceByName")
         }
     }
 


### PR DESCRIPTION
When the server returns 0 one_time_keys we also check the `CryptoAccount` to see if it has keys, if so we avoid generated new keys and in turn avoid over rotating the keys