### PR TITLE
Improved room name parsing

### DIFF
--- a/features/settings/src/test/kotlin/app/dapk/st/settings/SettingsItemFactoryTest.kt
+++ b/features/settings/src/test/kotlin/app/dapk/st/settings/SettingsItemFactoryTest.kt
@@ -18,7 +18,7 @@ private const val ENABLED_MATERIAL_YOU = true
 
 class SettingsItemFactoryTest {
 
-    private val buildMeta = BuildMeta(versionName = "a-version-name", versionCode = 100)
+    private val buildMeta = BuildMeta(versionName = "a-version-name", versionCode = 100, isDebug = false)
     private val deviceMeta = DeviceMeta(apiVersion = 31)
     private val fakePushTokenRegistrars = FakePushRegistrars()
     private val fakeThemeStore = FakeThemeStore()

--- a/matrix/services/sync/src/main/kotlin/app/dapk/st/matrix/sync/internal/request/ApiSyncResponse.kt
+++ b/matrix/services/sync/src/main/kotlin/app/dapk/st/matrix/sync/internal/request/ApiSyncResponse.kt
@@ -56,6 +56,12 @@ internal data class ApiSyncRoom(
     @SerialName("state") val state: ApiSyncRoomState,
     @SerialName("account_data") val accountData: ApiAccountData? = null,
     @SerialName("ephemeral") val ephemeral: ApiEphemeral? = null,
+    @SerialName("summary") val summary: ApiRoomSummary? = null,
+)
+
+@Serializable
+internal data class ApiRoomSummary(
+    @SerialName("m.heroes") val heroes: List<UserId>? = null
 )
 
 @Serializable

--- a/matrix/services/sync/src/main/kotlin/app/dapk/st/matrix/sync/internal/request/ApiTimelineEvent.kt
+++ b/matrix/services/sync/src/main/kotlin/app/dapk/st/matrix/sync/internal/request/ApiTimelineEvent.kt
@@ -50,6 +50,18 @@ internal sealed class ApiTimelineEvent {
         )
     }
 
+    @Serializable
+    @SerialName("m.room.canonical_alias")
+    internal data class CanonicalAlias(
+        @SerialName("event_id") val id: EventId,
+        @SerialName("content") val content: Content,
+    ) : ApiTimelineEvent() {
+
+        @Serializable
+        internal data class Content(
+            @SerialName("alias") val alias: String
+        )
+    }
 
     @Serializable
     @SerialName("m.room.avatar")

--- a/matrix/services/sync/src/main/kotlin/app/dapk/st/matrix/sync/internal/sync/RoomOverviewProcessor.kt
+++ b/matrix/services/sync/src/main/kotlin/app/dapk/st/matrix/sync/internal/sync/RoomOverviewProcessor.kt
@@ -15,16 +15,14 @@ internal class RoomOverviewProcessor(
     suspend fun process(roomToProcess: RoomToProcess, previousState: RoomOverview?, lastMessage: LastMessage?): RoomOverview {
         val combinedEvents = roomToProcess.apiSyncRoom.state.stateEvents + roomToProcess.apiSyncRoom.timeline.apiTimelineEvents
         val isEncrypted = combinedEvents.any { it is ApiTimelineEvent.Encryption }
-
         val readMarker = roomToProcess.apiSyncRoom.accountData?.events?.filterIsInstance<ApiAccountEvent.FullyRead>()?.firstOrNull()?.content?.eventId
         return when (previousState) {
             null -> combinedEvents.filterIsInstance<ApiTimelineEvent.RoomCreate>().first().let { roomCreate ->
-                val roomName = roomDisplayName(combinedEvents)
+                val roomName = roomDisplayName(roomToProcess, combinedEvents)
                 val isGroup = roomToProcess.directMessage == null
                 val processedName = roomName ?: roomToProcess.directMessage?.let {
                     roomMembersService.find(roomToProcess.roomId, it)?.let { it.displayName ?: it.id.value }
                 }
-
                 RoomOverview(
                     roomName = processedName,
                     roomCreationUtc = roomCreate.utcTimestamp,
@@ -45,7 +43,7 @@ internal class RoomOverviewProcessor(
 
             else -> {
                 previousState.copy(
-                    roomName = previousState.roomName ?: roomDisplayName(combinedEvents),
+                    roomName = previousState.roomName ?: roomDisplayName(roomToProcess, combinedEvents),
                     lastMessage = lastMessage ?: previousState.lastMessage,
                     roomAvatarUrl = previousState.roomAvatarUrl ?: roomAvatar(
                         roomToProcess.roomId,
@@ -61,10 +59,13 @@ internal class RoomOverviewProcessor(
         }
     }
 
-    private fun roomDisplayName(combinedEvents: List<ApiTimelineEvent>): String? {
-        val roomName = combinedEvents.filterIsInstance<ApiTimelineEvent.RoomName>().lastOrNull()
-        return (roomName?.content?.name)
+    private suspend fun roomDisplayName(roomToProcess: RoomToProcess, combinedEvents: List<ApiTimelineEvent>): String? {
+        val roomName = combinedEvents.filterIsInstance<ApiTimelineEvent.RoomName>().lastOrNull()?.content?.name
             ?: combinedEvents.filterIsInstance<ApiTimelineEvent.CanonicalAlias>().lastOrNull()?.content?.alias
+            ?: roomToProcess.heroes?.let {
+                roomMembersService.find(roomToProcess.roomId, it).joinToString { it.displayName ?: it.id.value }
+            }
+        return roomName?.takeIf { it.isNotEmpty() }
     }
 
     private suspend fun roomAvatar(

--- a/matrix/services/sync/src/main/kotlin/app/dapk/st/matrix/sync/internal/sync/RoomToProcess.kt
+++ b/matrix/services/sync/src/main/kotlin/app/dapk/st/matrix/sync/internal/sync/RoomToProcess.kt
@@ -10,4 +10,5 @@ internal data class RoomToProcess(
     val apiSyncRoom: ApiSyncRoom,
     val directMessage: UserId?,
     val userCredentials: UserCredentials,
+    val heroes: List<UserId>?,
 )

--- a/matrix/services/sync/src/main/kotlin/app/dapk/st/matrix/sync/internal/sync/SyncReducer.kt
+++ b/matrix/services/sync/src/main/kotlin/app/dapk/st/matrix/sync/internal/sync/SyncReducer.kt
@@ -30,7 +30,6 @@ internal class SyncReducer(
 
     suspend fun reduce(isInitialSync: Boolean, sideEffects: SideEffectResult, response: ApiSyncResponse, userCredentials: UserCredentials): ReducerResult {
         val directMessages = response.directMessages()
-
         val invites = response.rooms?.invite?.map { roomInvite(it, userCredentials) } ?: emptyList()
         val roomsLeft = findRoomsLeft(response, userCredentials)
         val newRooms = response.rooms?.join?.keys?.filterNot { roomDataSource.contains(it) } ?: emptyList()
@@ -46,6 +45,7 @@ internal class SyncReducer(
                             apiSyncRoom = apiRoom,
                             directMessage = directMessages[roomId],
                             userCredentials = userCredentials,
+                            heroes = apiRoom.summary?.heroes,
                         ),
                         isInitialSync = isInitialSync
                     )

--- a/matrix/services/sync/src/main/kotlin/app/dapk/st/matrix/sync/internal/sync/TimelineEventsProcessor.kt
+++ b/matrix/services/sync/src/main/kotlin/app/dapk/st/matrix/sync/internal/sync/TimelineEventsProcessor.kt
@@ -38,6 +38,7 @@ internal class TimelineEventsProcessor(
                     is ApiTimelineEvent.RoomMember -> null
                     is ApiTimelineEvent.RoomName -> null
                     is ApiTimelineEvent.RoomTopic -> null
+                    is ApiTimelineEvent.CanonicalAlias -> null
                     ApiTimelineEvent.Ignored -> null
                 }
                 roomEvent

--- a/matrix/services/sync/src/test/kotlin/app/dapk/st/matrix/sync/internal/sync/EphemeralEventsUseCaseTest.kt
+++ b/matrix/services/sync/src/test/kotlin/app/dapk/st/matrix/sync/internal/sync/EphemeralEventsUseCaseTest.kt
@@ -70,4 +70,5 @@ private fun aRoomToProcess(ephemeral: ApiEphemeral? = null) = RoomToProcess(
     anApiSyncRoom(ephemeral = ephemeral),
     directMessage = null,
     userCredentials = aUserCredentials(),
+    heroes = null,
 )

--- a/matrix/services/sync/src/test/kotlin/app/dapk/st/matrix/sync/internal/sync/TimelineEventsProcessorTest.kt
+++ b/matrix/services/sync/src/test/kotlin/app/dapk/st/matrix/sync/internal/sync/TimelineEventsProcessorTest.kt
@@ -101,4 +101,4 @@ internal fun aRoomToProcess(
     apiSyncRoom: ApiSyncRoom = anApiSyncRoom(),
     directMessage: UserId? = null,
     userCredentials: UserCredentials = aUserCredentials(),
-) = RoomToProcess(roomId, apiSyncRoom, directMessage, userCredentials)
+) = RoomToProcess(roomId, apiSyncRoom, directMessage, userCredentials, heroes = null)


### PR DESCRIPTION
- Fixes possible empty room names #147 
- Takes into account the `heroes` members when generating the room name, avoids "empty room" in scenarios where a `room name` event is  not present  