### PR TITLE
Image - In memory and disk caching

### DIFF
--- a/app/src/main/kotlin/app/dapk/st/SmallTalkApplication.kt
+++ b/app/src/main/kotlin/app/dapk/st/SmallTalkApplication.kt
@@ -54,7 +54,9 @@ class SmallTalkApplication : Application(), ModuleProvider {
 
     private fun onApplicationLaunch(notificationsModule: NotificationsModule, storeModule: StoreModule) {
         applicationScope.launch {
-            featureModules.pushModule.pushTokenRegistrar().registerCurrentToken()
+            storeModule.credentialsStore().credentials()?.let {
+                featureModules.pushModule.pushTokenRegistrar().registerCurrentToken()
+            }
             storeModule.localEchoStore.preload()
         }
 

--- a/features/messenger/src/main/AndroidManifest.xml
+++ b/features/messenger/src/main/AndroidManifest.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="app.dapk.st.messenger">
+          package="app.dapk.st.messenger">
 
     <application>
 
         <activity
             android:name=".MessengerActivity"
-            android:windowSoftInputMode="adjustResize" />
+            android:windowSoftInputMode="adjustResize"/>
 
-        <activity android:name=".roomsettings.RoomSettingsActivity" />
+        <activity android:name=".roomsettings.RoomSettingsActivity"/>
 
     </application>
 

--- a/features/messenger/src/main/kotlin/app/dapk/st/messenger/MessengerActivity.kt
+++ b/features/messenger/src/main/kotlin/app/dapk/st/messenger/MessengerActivity.kt
@@ -50,7 +50,7 @@ class MessengerActivity : DapkActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val payload = readPayload<MessagerActivityPayload>()
-        val factory = module.decryptingFetcherFactory()
+        val factory = module.decryptingFetcherFactory(RoomId(payload.roomId))
         setContent {
             Surface(Modifier.fillMaxSize()) {
                 CompositionLocalProvider(LocalDecyptingFetcherFactory provides factory) {

--- a/features/messenger/src/main/kotlin/app/dapk/st/messenger/MessengerModule.kt
+++ b/features/messenger/src/main/kotlin/app/dapk/st/messenger/MessengerModule.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import app.dapk.st.core.Base64
 import app.dapk.st.core.ProvidableModule
 import app.dapk.st.matrix.common.CredentialsStore
+import app.dapk.st.matrix.common.RoomId
 import app.dapk.st.matrix.message.MessageService
 import app.dapk.st.matrix.room.RoomService
 import app.dapk.st.matrix.sync.RoomStore
@@ -30,5 +31,5 @@ class MessengerModule(
         return TimelineUseCaseImpl(syncService, messageService, roomService, mergeWithLocalEchosUseCase)
     }
 
-    internal fun decryptingFetcherFactory() = DecryptingFetcherFactory(context, base64)
+    internal fun decryptingFetcherFactory(roomId: RoomId) = DecryptingFetcherFactory(context, base64, roomId)
 }

--- a/features/messenger/src/main/kotlin/app/dapk/st/messenger/MessengerScreen.kt
+++ b/features/messenger/src/main/kotlin/app/dapk/st/messenger/MessengerScreen.kt
@@ -258,6 +258,7 @@ private fun MessageImage(content: BubbleContent<RoomEvent.Image>) {
                     painter = rememberAsyncImagePainter(
                         model = ImageRequest.Builder(context)
                             .fetcherFactory(LocalDecyptingFetcherFactory.current)
+                            .memoryCacheKey(content.message.imageMeta.url)
                             .data(content.message)
                             .build()
                     ),
@@ -437,6 +438,7 @@ private fun ReplyBubbleContent(content: BubbleContent<RoomEvent.Reply>) {
                                 painter = rememberAsyncImagePainter(
                                     model = ImageRequest.Builder(context)
                                         .fetcherFactory(LocalDecyptingFetcherFactory.current)
+                                        .memoryCacheKey(replyingTo.imageMeta.url)
                                         .data(replyingTo)
                                         .build()
                                 ),
@@ -478,7 +480,8 @@ private fun ReplyBubbleContent(content: BubbleContent<RoomEvent.Reply>) {
                             modifier = Modifier.size(message.imageMeta.scale(LocalDensity.current, LocalConfiguration.current)),
                             painter = rememberAsyncImagePainter(
                                 model = ImageRequest.Builder(context)
-                                    .data(content.message)
+                                    .data(message)
+                                    .memoryCacheKey(message.imageMeta.url)
                                     .fetcherFactory(LocalDecyptingFetcherFactory.current)
                                     .build()
                             ),


### PR DESCRIPTION
- Adds in memory and disk image caching to support offline loading 
- Images are stored decrypted under data/media/dapk.app.st/{RoomId}
- Needs a second pass to reference the files by database lookup rather than the files directly