### PR TITLE
Various crypto fixes

### DIFF
--- a/domains/olm/src/main/kotlin/app/dapk/st/olm/OlmWrapper.kt
+++ b/domains/olm/src/main/kotlin/app/dapk/st/olm/OlmWrapper.kt
@@ -170,6 +170,8 @@ class OlmWrapper(
         val inBound = OlmInboundGroupSession(roomCryptoSession.key)
         olmStore.persist(roomCryptoSession.id, inBound)
 
+        logger.crypto("Creating megolm: ${roomCryptoSession.id}")
+
         return roomCryptoSession
     }
 
@@ -181,7 +183,7 @@ class OlmWrapper(
     private suspend fun deviceCrypto(input: OlmSessionInput): DeviceCryptoSession? {
         return olmStore.readSessions(listOf(input.identity))?.let {
             DeviceCryptoSession(
-                input.deviceId, input.userId, input.identity, input.fingerprint, it
+                input.deviceId, input.userId, input.identity, input.fingerprint, it.map { it.second }
             )
         }
     }

--- a/matrix/matrix/src/main/kotlin/app/dapk/st/matrix/MatrixClient.kt
+++ b/matrix/matrix/src/main/kotlin/app/dapk/st/matrix/MatrixClient.kt
@@ -43,7 +43,11 @@ data class ServiceDependencies(
 
 interface MatrixServiceInstaller {
     fun serializers(builder: SerializersModuleBuilder.() -> Unit)
-    fun install(factory: MatrixService.Factory)
+    fun <T : MatrixService> install(factory: MatrixService.Factory): InstallExtender<T>
+}
+
+interface InstallExtender<T : MatrixService> {
+    fun proxy(proxy: (T) -> T)
 }
 
 interface MatrixServiceProvider {

--- a/matrix/services/auth/src/main/kotlin/app/dapk/st/matrix/auth/AuthService.kt
+++ b/matrix/services/auth/src/main/kotlin/app/dapk/st/matrix/auth/AuthService.kt
@@ -1,5 +1,6 @@
 package app.dapk.st.matrix.auth
 
+import app.dapk.st.matrix.InstallExtender
 import app.dapk.st.matrix.MatrixClient
 import app.dapk.st.matrix.MatrixService
 import app.dapk.st.matrix.MatrixServiceInstaller
@@ -25,8 +26,8 @@ interface AuthService : MatrixService {
 
 fun MatrixServiceInstaller.installAuthService(
     credentialsStore: CredentialsStore,
-) {
-    this.install { (httpClient, json) ->
+): InstallExtender<AuthService> {
+    return this.install { (httpClient, json) ->
         SERVICE_KEY to DefaultAuthService(httpClient, credentialsStore, json)
     }
 }

--- a/matrix/services/crypto/src/main/kotlin/app/dapk/st/matrix/crypto/CryptoService.kt
+++ b/matrix/services/crypto/src/main/kotlin/app/dapk/st/matrix/crypto/CryptoService.kt
@@ -2,10 +2,7 @@ package app.dapk.st.matrix.crypto
 
 import app.dapk.st.core.Base64
 import app.dapk.st.core.CoroutineDispatchers
-import app.dapk.st.matrix.MatrixService
-import app.dapk.st.matrix.MatrixServiceInstaller
-import app.dapk.st.matrix.MatrixServiceProvider
-import app.dapk.st.matrix.ServiceDepFactory
+import app.dapk.st.matrix.*
 import app.dapk.st.matrix.common.*
 import app.dapk.st.matrix.crypto.internal.*
 import app.dapk.st.matrix.device.deviceService
@@ -136,8 +133,8 @@ fun MatrixServiceInstaller.installCryptoService(
     roomMembersProvider: ServiceDepFactory<RoomMembersProvider>,
     base64: Base64,
     coroutineDispatchers: CoroutineDispatchers,
-) {
-    this.install { (_, _, services, logger) ->
+): InstallExtender<CryptoService> {
+    return this.install { (_, _, services, logger) ->
         val deviceService = services.deviceService()
         val accountCryptoUseCase = FetchAccountCryptoUseCaseImpl(credentialsStore, olm, deviceService)
 

--- a/matrix/services/device/src/main/kotlin/app/dapk/st/matrix/device/DeviceService.kt
+++ b/matrix/services/device/src/main/kotlin/app/dapk/st/matrix/device/DeviceService.kt
@@ -1,5 +1,6 @@
 package app.dapk.st.matrix.device
 
+import app.dapk.st.matrix.InstallExtender
 import app.dapk.st.matrix.MatrixService
 import app.dapk.st.matrix.MatrixServiceInstaller
 import app.dapk.st.matrix.MatrixServiceProvider
@@ -122,8 +123,8 @@ sealed class ToDevicePayload {
     sealed interface VerificationPayload
 }
 
-fun MatrixServiceInstaller.installEncryptionService(knownDeviceStore: KnownDeviceStore) {
-    this.install { (httpClient, _, _, logger) ->
+fun MatrixServiceInstaller.installEncryptionService(knownDeviceStore: KnownDeviceStore): InstallExtender<DeviceService> {
+    return this.install { (httpClient, _, _, logger) ->
         SERVICE_KEY to DefaultDeviceService(httpClient, logger, knownDeviceStore)
     }
 }

--- a/matrix/services/message/src/main/kotlin/app/dapk/st/matrix/message/MessageService.kt
+++ b/matrix/services/message/src/main/kotlin/app/dapk/st/matrix/message/MessageService.kt
@@ -1,10 +1,7 @@
 package app.dapk.st.matrix.message
 
 import app.dapk.st.core.Base64
-import app.dapk.st.matrix.MatrixService
-import app.dapk.st.matrix.MatrixServiceInstaller
-import app.dapk.st.matrix.MatrixServiceProvider
-import app.dapk.st.matrix.ServiceDepFactory
+import app.dapk.st.matrix.*
 import app.dapk.st.matrix.common.AlgorithmName
 import app.dapk.st.matrix.common.EventId
 import app.dapk.st.matrix.common.MessageType
@@ -132,8 +129,8 @@ fun MatrixServiceInstaller.installMessageService(
     imageContentReader: ImageContentReader,
     messageEncrypter: ServiceDepFactory<MessageEncrypter> = ServiceDepFactory { MissingMessageEncrypter },
     mediaEncrypter: ServiceDepFactory<MediaEncrypter> = ServiceDepFactory { MissingMediaEncrypter },
-) {
-    this.install { (httpClient, _, installedServices) ->
+): InstallExtender<MessageService> {
+    return this.install { (httpClient, _, installedServices) ->
         SERVICE_KEY to DefaultMessageService(
             httpClient,
             localEchoStore,

--- a/matrix/services/profile/src/main/kotlin/app/dapk/st/matrix/room/ProfileService.kt
+++ b/matrix/services/profile/src/main/kotlin/app/dapk/st/matrix/room/ProfileService.kt
@@ -1,6 +1,7 @@
 package app.dapk.st.matrix.room
 
 import app.dapk.st.core.SingletonFlows
+import app.dapk.st.matrix.InstallExtender
 import app.dapk.st.matrix.MatrixService
 import app.dapk.st.matrix.MatrixServiceInstaller
 import app.dapk.st.matrix.MatrixServiceProvider
@@ -29,8 +30,8 @@ fun MatrixServiceInstaller.installProfileService(
     profileStore: ProfileStore,
     singletonFlows: SingletonFlows,
     credentialsStore: CredentialsStore,
-) {
-    this.install { (httpClient, _, _, logger) ->
+): InstallExtender<ProfileService> {
+    return this.install { (httpClient, _, _, logger) ->
         SERVICE_KEY to DefaultProfileService(httpClient, logger, profileStore, singletonFlows, credentialsStore)
     }
 }

--- a/matrix/services/push/src/main/kotlin/app/dapk/st/matrix/push/PushService.kt
+++ b/matrix/services/push/src/main/kotlin/app/dapk/st/matrix/push/PushService.kt
@@ -1,5 +1,6 @@
 package app.dapk.st.matrix.push
 
+import app.dapk.st.matrix.InstallExtender
 import app.dapk.st.matrix.MatrixClient
 import app.dapk.st.matrix.MatrixService
 import app.dapk.st.matrix.MatrixServiceInstaller
@@ -38,8 +39,8 @@ interface PushService : MatrixService {
 
 fun MatrixServiceInstaller.installPushService(
     credentialsStore: CredentialsStore,
-) {
-    this.install { (httpClient, _, _, logger) ->
+): InstallExtender<PushService> {
+    return this.install { (httpClient, _, _, logger) ->
         SERVICE_KEY to DefaultPushService(httpClient, credentialsStore, logger)
     }
 }

--- a/matrix/services/room/src/main/kotlin/app/dapk/st/matrix/room/RoomService.kt
+++ b/matrix/services/room/src/main/kotlin/app/dapk/st/matrix/room/RoomService.kt
@@ -1,9 +1,6 @@
 package app.dapk.st.matrix.room
 
-import app.dapk.st.matrix.MatrixService
-import app.dapk.st.matrix.MatrixServiceInstaller
-import app.dapk.st.matrix.MatrixServiceProvider
-import app.dapk.st.matrix.ServiceDepFactory
+import app.dapk.st.matrix.*
 import app.dapk.st.matrix.common.EventId
 import app.dapk.st.matrix.common.RoomId
 import app.dapk.st.matrix.common.RoomMember
@@ -42,8 +39,8 @@ fun MatrixServiceInstaller.installRoomService(
     memberStore: MemberStore,
     roomMessenger: ServiceDepFactory<RoomMessenger>,
     roomInviteRemover: RoomInviteRemover,
-) {
-    this.install { (httpClient, _, services, logger) ->
+): InstallExtender<RoomService> {
+    return this.install { (httpClient, _, services, logger) ->
         SERVICE_KEY to DefaultRoomService(
             httpClient,
             logger,

--- a/matrix/services/sync/src/main/kotlin/app/dapk/st/matrix/sync/SyncService.kt
+++ b/matrix/services/sync/src/main/kotlin/app/dapk/st/matrix/sync/SyncService.kt
@@ -2,10 +2,7 @@ package app.dapk.st.matrix.sync
 
 import app.dapk.st.core.CoroutineDispatchers
 import app.dapk.st.core.extensions.ErrorTracker
-import app.dapk.st.matrix.MatrixClient
-import app.dapk.st.matrix.MatrixService
-import app.dapk.st.matrix.MatrixServiceInstaller
-import app.dapk.st.matrix.ServiceDepFactory
+import app.dapk.st.matrix.*
 import app.dapk.st.matrix.common.*
 import app.dapk.st.matrix.sync.internal.DefaultSyncService
 import app.dapk.st.matrix.sync.internal.request.*
@@ -49,7 +46,7 @@ fun MatrixServiceInstaller.installSyncService(
     errorTracker: ErrorTracker,
     coroutineDispatchers: CoroutineDispatchers,
     syncConfig: SyncConfig = SyncConfig(),
-) {
+): InstallExtender<SyncService> {
     this.serializers {
         polymorphicDefault(ApiTimelineEvent::class) {
             ApiTimelineEvent.Ignored.serializer()
@@ -71,7 +68,7 @@ fun MatrixServiceInstaller.installSyncService(
         }
     }
 
-    this.install { (httpClient, json, services, logger) ->
+    return this.install { (httpClient, json, services, logger) ->
         SERVICE_KEY to DefaultSyncService(
             httpClient = httpClient,
             syncStore = syncStore,

--- a/test-harness/src/test/kotlin/SmokeTest.kt
+++ b/test-harness/src/test/kotlin/SmokeTest.kt
@@ -123,18 +123,20 @@ class SmokeTest {
         alice.expectTextMessage(SharedState.sharedRoom, message2)
 
         // Needs investigation
-//        val aliceSecondDevice = testMatrix(SharedState.alice, isTemp = true, withLogging = true).also { it.newlogin() }
-//        aliceSecondDevice.client.syncService().startSyncing().collectAsync {
-//            val message3 = "from alice to bob and alice's second device".from(SharedState.alice.roomMember)
-//            alice.sendTextMessage(SharedState.sharedRoom, message3.content, isEncrypted)
-//            aliceSecondDevice.expectTextMessage(SharedState.sharedRoom, message3)
-//            bob.expectTextMessage(SharedState.sharedRoom, message3)
-//
-//            val message4 = "from alice's second device to bob and alice's first device".from(SharedState.alice.roomMember)
-//            aliceSecondDevice.sendTextMessage(SharedState.sharedRoom, message4.content, isEncrypted)
-//            alice.expectTextMessage(SharedState.sharedRoom, message4)
-//            bob.expectTextMessage(SharedState.sharedRoom, message4)
-//        }
+        val aliceSecondDevice = testMatrix(SharedState.alice, isTemp = true, withLogging = true).also { it.newlogin() }
+        aliceSecondDevice.client.syncService().startSyncing().collectAsync {
+            aliceSecondDevice.client.proxyDeviceService().waitForOneTimeKeysToBeUploaded()
+
+            val message3 = "from alice to bob and alice's second device".from(SharedState.alice.roomMember)
+            alice.sendTextMessage(SharedState.sharedRoom, message3.content, isEncrypted)
+            aliceSecondDevice.expectTextMessage(SharedState.sharedRoom, message3)
+            bob.expectTextMessage(SharedState.sharedRoom, message3)
+
+            val message4 = "from alice's second device to bob and alice's first device".from(SharedState.alice.roomMember)
+            aliceSecondDevice.sendTextMessage(SharedState.sharedRoom, message4.content, isEncrypted)
+            alice.expectTextMessage(SharedState.sharedRoom, message4)
+            bob.expectTextMessage(SharedState.sharedRoom, message4)
+        }
     }
 }
 


### PR DESCRIPTION
- Adds ability within tests to to proxy matrix services 
- Re-enables 2nd device messaging checks within the smoke tests
- Fixes wrong instance being passed when creating `deviceCrypto`