### PR TITLE
Providing error details on login

### DIFF
--- a/features/login/src/main/kotlin/app/dapk/st/login/LoginScreen.kt
+++ b/features/login/src/main/kotlin/app/dapk/st/login/LoginScreen.kt
@@ -1,15 +1,16 @@
 package app.dapk.st.login
 
 import android.widget.Toast
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material.icons.filled.Web
 import androidx.compose.material.icons.outlined.Lock
+import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
@@ -49,10 +50,27 @@ fun LoginScreen(loginViewModel: LoginViewModel, onLoggedIn: () -> Unit) {
 
     when (val state = loginViewModel.state) {
         is Error -> {
+            val openDetailsDialog = remember { mutableStateOf(false) }
+
+            if (openDetailsDialog.value) {
+                AlertDialog(
+                    onDismissRequest = { openDetailsDialog.value = false },
+                    confirmButton = {
+                        Button(onClick = { openDetailsDialog.value = false }) {
+                            Text("OK")
+                        }
+                    },
+                    title = { Text("Details") },
+                    text = {
+                        Text(state.cause.message ?: "Unknown")
+                    }
+                )
+            }
             Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
                     Text("Something went wrong")
-                    Spacer(modifier = Modifier.height(6.dp))
+                    Text("Tap for more details".uppercase(), fontSize = 12.sp, modifier = Modifier.clickable { openDetailsDialog.value = true }.padding(12.dp))
+                    Spacer(modifier = Modifier.height(12.dp))
                     Button(onClick = {
                         loginViewModel.start()
                     }) {
@@ -61,11 +79,13 @@ fun LoginScreen(loginViewModel: LoginViewModel, onLoggedIn: () -> Unit) {
                 }
             }
         }
+
         Loading -> {
             Box(contentAlignment = Alignment.Center) {
                 CircularProgressIndicator()
             }
         }
+
         is Content ->
             Row {
                 Spacer(modifier = Modifier.weight(0.1f))


### PR DESCRIPTION
Adds a dialog to provide more details about a given error, will help users provide information to debug their errors.

| ERROR | DETAILS |
| --- | --- |
![Screenshot_20220930_213757](https://user-images.githubusercontent.com/1848238/193352765-854f7488-b333-4146-ad56-2142fa0da26c.png)|![Screenshot_20220930_213805](https://user-images.githubusercontent.com/1848238/193352771-fe539fd2-3c7b-4099-8f0e-a0efb0a1e516.png)
