### PR TITLE
Logging and read receipt settings

### DIFF
--- a/app/src/main/kotlin/app/dapk/st/SmallTalkApplication.kt
+++ b/app/src/main/kotlin/app/dapk/st/SmallTalkApplication.kt
@@ -42,10 +42,15 @@ class SmallTalkApplication : Application(), ModuleProvider {
         val notificationsModule = featureModules.notificationsModule
         val storeModule = appModule.storeModule.value
         val eventLogStore = storeModule.eventLogStore()
+        val loggingStore = storeModule.loggingStore()
 
         val logger: (String, String) -> Unit = { tag, message ->
             Log.e(tag, message)
-            applicationScope.launch { eventLogStore.insert(tag, message) }
+            applicationScope.launch {
+                if (loggingStore.isEnabled()) {
+                    eventLogStore.insert(tag, message)
+                }
+            }
         }
         attachAppLogger(logger)
         _appLogger = logger

--- a/app/src/main/kotlin/app/dapk/st/graph/AppModule.kt
+++ b/app/src/main/kotlin/app/dapk/st/graph/AppModule.kt
@@ -205,6 +205,7 @@ internal class FeatureModules internal constructor(
             deviceMeta,
             coroutineDispatchers,
             coreAndroidModule.themeStore(),
+            storeModule.value.loggingStore(),
         )
     }
     val profileModule by unsafeLazy { ProfileModule(matrixModules.profile, matrixModules.sync, matrixModules.room, trackingModule.errorTracker) }

--- a/app/src/main/kotlin/app/dapk/st/graph/AppModule.kt
+++ b/app/src/main/kotlin/app/dapk/st/graph/AppModule.kt
@@ -126,7 +126,7 @@ internal class AppModule(context: Application, logger: MatrixLogger) {
                 attachments
             )
         },
-        unsafeLazy { storeModule.value.preferences }
+        unsafeLazy { storeModule.value.cachingPreferences },
     )
 
     val featureModules = FeatureModules(

--- a/app/src/main/kotlin/app/dapk/st/graph/AppModule.kt
+++ b/app/src/main/kotlin/app/dapk/st/graph/AppModule.kt
@@ -191,6 +191,7 @@ internal class FeatureModules internal constructor(
             context,
             base64,
             imageContentReader,
+            storeModule.value.messageStore(),
         )
     }
     val homeModule by unsafeLazy { HomeModule(storeModule.value, matrixModules.profile, matrixModules.sync, buildMeta) }
@@ -206,6 +207,7 @@ internal class FeatureModules internal constructor(
             coroutineDispatchers,
             coreAndroidModule.themeStore(),
             storeModule.value.loggingStore(),
+            storeModule.value.messageStore(),
         )
     }
     val profileModule by unsafeLazy { ProfileModule(matrixModules.profile, matrixModules.sync, matrixModules.room, trackingModule.errorTracker) }

--- a/core/src/main/kotlin/app/dapk/st/core/Preferences.kt
+++ b/core/src/main/kotlin/app/dapk/st/core/Preferences.kt
@@ -8,7 +8,13 @@ interface Preferences {
     suspend fun remove(key: String)
 }
 
-interface CachedPreferences : Preferences
+interface CachedPreferences : Preferences {
+    suspend fun readString(key: String, defaultValue: String): String
+}
+
+suspend fun CachedPreferences.readBoolean(key: String, defaultValue: Boolean) = this
+    .readString(key, defaultValue.toString())
+    .toBooleanStrict()
 
 suspend fun Preferences.readBoolean(key: String) = this.readString(key)?.toBooleanStrict()
 suspend fun Preferences.store(key: String, value: Boolean) = this.store(key, value.toString())

--- a/core/src/main/kotlin/app/dapk/st/core/Preferences.kt
+++ b/core/src/main/kotlin/app/dapk/st/core/Preferences.kt
@@ -8,5 +8,7 @@ interface Preferences {
     suspend fun remove(key: String)
 }
 
+interface CachedPreferences : Preferences
+
 suspend fun Preferences.readBoolean(key: String) = this.readString(key)?.toBooleanStrict()
 suspend fun Preferences.store(key: String, value: Boolean) = this.store(key, value.toString())

--- a/design-library/src/main/kotlin/app/dapk/st/design/components/itemRow.kt
+++ b/design-library/src/main/kotlin/app/dapk/st/design/components/itemRow.kt
@@ -2,9 +2,7 @@ package app.dapk.st.design.components
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
-import androidx.compose.material3.Divider
-import androidx.compose.material3.Icon
-import androidx.compose.material3.Text
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -22,12 +20,13 @@ fun TextRow(
     enabled: Boolean = true,
     body: @Composable () -> Unit = {}
 ) {
+    val verticalPadding = 24.dp
     val modifier = Modifier.padding(horizontal = 24.dp)
     Column(
         Modifier
             .fillMaxWidth()
             .clickable(enabled = onClick != null) { onClick?.invoke() }) {
-        Spacer(modifier = Modifier.height(24.dp))
+        Spacer(modifier = Modifier.height(verticalPadding))
         Column(modifier) {
             val textModifier = when (enabled) {
                 true -> Modifier
@@ -45,7 +44,7 @@ fun TextRow(
                 }
             }
             body()
-            Spacer(modifier = Modifier.height(24.dp))
+            Spacer(modifier = Modifier.height(verticalPadding))
         }
         if (includeDivider) {
             Divider(modifier = Modifier.fillMaxWidth())
@@ -72,3 +71,36 @@ fun IconRow(icon: ImageVector, title: String, onClick: (() -> Unit)? = null) {
 fun SettingsTextRow(title: String, subtitle: String?, onClick: (() -> Unit)?, enabled: Boolean) {
     TextRow(title = title, subtitle, includeDivider = false, onClick, enabled = enabled)
 }
+
+@Composable
+fun SettingsToggleRow(title: String, subtitle: String?, state: Boolean, onToggle: () -> Unit) {
+    Toggle(title, subtitle, state, onToggle)
+}
+
+@Composable
+private fun Toggle(title: String, subtitle: String?, state: Boolean, onToggle: () -> Unit) {
+    val verticalPadding = 16.dp
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 24.dp, vertical = verticalPadding),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        if  (subtitle == null) {
+            Text(text = title)
+        } else {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(text = title)
+                Spacer(Modifier.height(4.dp))
+                Text(text = subtitle, fontSize = 12.sp, color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.8f))
+            }
+        }
+        Switch(
+            modifier = Modifier.wrapContentWidth(),
+            checked = state,
+            onCheckedChange = { onToggle() }
+        )
+    }
+}
+

--- a/design-library/src/main/kotlin/app/dapk/st/design/components/itemRow.kt
+++ b/design-library/src/main/kotlin/app/dapk/st/design/components/itemRow.kt
@@ -8,12 +8,20 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
 @Composable
-fun TextRow(title: String, content: String? = null, includeDivider: Boolean = true, onClick: (() -> Unit)? = null, body: @Composable () -> Unit = {}) {
+fun TextRow(
+    title: String,
+    content: String? = null,
+    includeDivider: Boolean = true,
+    onClick: (() -> Unit)? = null,
+    enabled: Boolean = true,
+    body: @Composable () -> Unit = {}
+) {
     val modifier = Modifier.padding(horizontal = 24.dp)
     Column(
         Modifier
@@ -21,14 +29,19 @@ fun TextRow(title: String, content: String? = null, includeDivider: Boolean = tr
             .clickable(enabled = onClick != null) { onClick?.invoke() }) {
         Spacer(modifier = Modifier.height(24.dp))
         Column(modifier) {
+            val textModifier = when (enabled) {
+                true -> Modifier
+                false -> Modifier.alpha(0.5f)
+            }
             when (content) {
                 null -> {
-                    Text(text = title, fontSize = 18.sp)
+                    Text(text = title, fontSize = 18.sp, modifier = textModifier)
                 }
+
                 else -> {
-                    Text(text = title, fontSize = 12.sp)
+                    Text(text = title, fontSize = 12.sp, modifier = textModifier)
                     Spacer(modifier = Modifier.height(2.dp))
-                    Text(text = content, fontSize = 18.sp)
+                    Text(text = content, fontSize = 18.sp, modifier = textModifier)
                 }
             }
             body()
@@ -56,6 +69,6 @@ fun IconRow(icon: ImageVector, title: String, onClick: (() -> Unit)? = null) {
 }
 
 @Composable
-fun SettingsTextRow(title: String, subtitle: String?, onClick: (() -> Unit)?) {
-    TextRow(title = title, subtitle, includeDivider = false, onClick)
+fun SettingsTextRow(title: String, subtitle: String?, onClick: (() -> Unit)?, enabled: Boolean) {
+    TextRow(title = title, subtitle, includeDivider = false, onClick, enabled = enabled)
 }

--- a/domains/android/compose-core/src/main/kotlin/app/dapk/st/core/CoreAndroidModule.kt
+++ b/domains/android/compose-core/src/main/kotlin/app/dapk/st/core/CoreAndroidModule.kt
@@ -1,17 +1,14 @@
 package app.dapk.st.core
 
-import app.dapk.st.core.extensions.unsafeLazy
 import app.dapk.st.navigator.IntentFactory
 
 class CoreAndroidModule(
     private val intentFactory: IntentFactory,
-    private val preferences: Lazy<Preferences>,
+    private val preferences: Lazy<CachedPreferences>,
 ) : ProvidableModule {
 
     fun intentFactory() = intentFactory
 
-    private val themeStore by unsafeLazy { ThemeStore(preferences.value) }
-
-    fun themeStore() = themeStore
+    fun themeStore() = ThemeStore(preferences.value)
 
 }

--- a/domains/android/compose-core/src/main/kotlin/app/dapk/st/core/DapkActivity.kt
+++ b/domains/android/compose-core/src/main/kotlin/app/dapk/st/core/DapkActivity.kt
@@ -8,10 +8,13 @@ import androidx.activity.ComponentActivity
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
+import androidx.lifecycle.lifecycleScope
 import app.dapk.st.core.extensions.unsafeLazy
 import app.dapk.st.design.components.SmallTalkTheme
 import app.dapk.st.design.components.ThemeConfig
 import app.dapk.st.navigator.navigator
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlin.coroutines.resume
 import androidx.activity.compose.setContent as _setContent
@@ -29,7 +32,7 @@ abstract class DapkActivity : ComponentActivity(), EffectScope {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        this.themeConfig = ThemeConfig(themeStore.isMaterialYouEnabled())
+        this.themeConfig = runBlocking { ThemeConfig(themeStore.isMaterialYouEnabled()) }
 
         window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
         window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
@@ -45,8 +48,10 @@ abstract class DapkActivity : ComponentActivity(), EffectScope {
 
     override fun onResume() {
         super.onResume()
-        if (themeConfig.useDynamicTheme != themeStore.isMaterialYouEnabled()) {
-            recreate()
+        lifecycleScope.launch {
+            if (themeConfig.useDynamicTheme != themeStore.isMaterialYouEnabled()) {
+                recreate()
+            }
         }
     }
 

--- a/domains/android/compose-core/src/main/kotlin/app/dapk/st/core/ThemeStore.kt
+++ b/domains/android/compose-core/src/main/kotlin/app/dapk/st/core/ThemeStore.kt
@@ -6,7 +6,7 @@ class ThemeStore(
     private val preferences: CachedPreferences
 ) {
 
-    suspend fun isMaterialYouEnabled() = preferences.readBoolean(KEY_MATERIAL_YOU_ENABLED) ?: false.also { storeMaterialYouEnabled(false) }
+    suspend fun isMaterialYouEnabled() = preferences.readBoolean(KEY_MATERIAL_YOU_ENABLED, defaultValue = false)
 
     suspend fun storeMaterialYouEnabled(isEnabled: Boolean) {
         preferences.store(KEY_MATERIAL_YOU_ENABLED, isEnabled)

--- a/domains/android/compose-core/src/main/kotlin/app/dapk/st/core/ThemeStore.kt
+++ b/domains/android/compose-core/src/main/kotlin/app/dapk/st/core/ThemeStore.kt
@@ -1,25 +1,14 @@
 package app.dapk.st.core
 
-import kotlinx.coroutines.runBlocking
-
 private const val KEY_MATERIAL_YOU_ENABLED = "material_you_enabled"
 
 class ThemeStore(
-    private val preferences: Preferences
+    private val preferences: CachedPreferences
 ) {
 
-    private var _isMaterialYouEnabled: Boolean? = null
-
-    fun isMaterialYouEnabled() = _isMaterialYouEnabled ?: blockingInitialRead()
-
-    private fun blockingInitialRead(): Boolean {
-        return runBlocking {
-            (preferences.readBoolean(KEY_MATERIAL_YOU_ENABLED) ?: false).also { _isMaterialYouEnabled = it }
-        }
-    }
+    suspend fun isMaterialYouEnabled() = preferences.readBoolean(KEY_MATERIAL_YOU_ENABLED) ?: false.also { storeMaterialYouEnabled(false) }
 
     suspend fun storeMaterialYouEnabled(isEnabled: Boolean) {
-        _isMaterialYouEnabled = isEnabled
         preferences.store(KEY_MATERIAL_YOU_ENABLED, isEnabled)
     }
 

--- a/domains/store/build.gradle
+++ b/domains/store/build.gradle
@@ -25,4 +25,5 @@ dependencies {
     implementation "com.squareup.sqldelight:coroutines-extensions:1.5.3"
 
     kotlinFixtures(it)
-}
+    testImplementation(testFixtures(project(":core")))
+    testFixturesImplementation(testFixtures(project(":core")))}

--- a/domains/store/src/main/kotlin/app/dapk/st/domain/StoreModule.kt
+++ b/domains/store/src/main/kotlin/app/dapk/st/domain/StoreModule.kt
@@ -6,6 +6,7 @@ import app.dapk.st.core.Preferences
 import app.dapk.st.core.extensions.ErrorTracker
 import app.dapk.st.core.extensions.unsafeLazy
 import app.dapk.st.domain.eventlog.EventLogPersistence
+import app.dapk.st.domain.eventlog.LoggingStore
 import app.dapk.st.domain.localecho.LocalEchoPersistence
 import app.dapk.st.domain.preference.CachingPreferences
 import app.dapk.st.domain.preference.PropertyCache
@@ -39,7 +40,7 @@ class StoreModule(
     val localEchoStore: LocalEchoStore by unsafeLazy { LocalEchoPersistence(errorTracker, database) }
 
     private val cache = PropertyCache()
-    val cachingPreferences = CachingPreferences(cache,  preferences)
+    val cachingPreferences = CachingPreferences(cache, preferences)
 
     fun pushStore() = PushTokenRegistrarPreferences(preferences)
 
@@ -61,6 +62,8 @@ class StoreModule(
     fun eventLogStore(): EventLogPersistence {
         return EventLogPersistence(database, coroutineDispatchers)
     }
+
+    fun loggingStore(): LoggingStore = LoggingStore(cachingPreferences)
 
     fun memberStore(): MemberStore {
         return MemberPersistence(database, coroutineDispatchers)

--- a/domains/store/src/main/kotlin/app/dapk/st/domain/StoreModule.kt
+++ b/domains/store/src/main/kotlin/app/dapk/st/domain/StoreModule.kt
@@ -7,6 +7,8 @@ import app.dapk.st.core.extensions.ErrorTracker
 import app.dapk.st.core.extensions.unsafeLazy
 import app.dapk.st.domain.eventlog.EventLogPersistence
 import app.dapk.st.domain.localecho.LocalEchoPersistence
+import app.dapk.st.domain.preference.CachingPreferences
+import app.dapk.st.domain.preference.PropertyCache
 import app.dapk.st.domain.profile.ProfilePersistence
 import app.dapk.st.domain.push.PushTokenRegistrarPreferences
 import app.dapk.st.domain.sync.OverviewPersistence
@@ -36,6 +38,9 @@ class StoreModule(
     fun filterStore(): FilterStore = FilterPreferences(preferences)
     val localEchoStore: LocalEchoStore by unsafeLazy { LocalEchoPersistence(errorTracker, database) }
 
+    private val cache = PropertyCache()
+    val cachingPreferences = CachingPreferences(cache,  preferences)
+
     fun pushStore() = PushTokenRegistrarPreferences(preferences)
 
     fun applicationStore() = ApplicationPreferences(preferences)
@@ -60,4 +65,5 @@ class StoreModule(
     fun memberStore(): MemberStore {
         return MemberPersistence(database, coroutineDispatchers)
     }
+
 }

--- a/domains/store/src/main/kotlin/app/dapk/st/domain/StoreModule.kt
+++ b/domains/store/src/main/kotlin/app/dapk/st/domain/StoreModule.kt
@@ -5,8 +5,9 @@ import app.dapk.st.core.CoroutineDispatchers
 import app.dapk.st.core.Preferences
 import app.dapk.st.core.extensions.ErrorTracker
 import app.dapk.st.core.extensions.unsafeLazy
-import app.dapk.st.domain.eventlog.EventLogPersistence
-import app.dapk.st.domain.eventlog.LoggingStore
+import app.dapk.st.domain.application.eventlog.EventLogPersistence
+import app.dapk.st.domain.application.eventlog.LoggingStore
+import app.dapk.st.domain.application.message.MessageOptionsStore
 import app.dapk.st.domain.localecho.LocalEchoPersistence
 import app.dapk.st.domain.preference.CachingPreferences
 import app.dapk.st.domain.preference.PropertyCache
@@ -64,6 +65,8 @@ class StoreModule(
     }
 
     fun loggingStore(): LoggingStore = LoggingStore(cachingPreferences)
+
+    fun messageStore(): MessageOptionsStore = MessageOptionsStore(cachingPreferences)
 
     fun memberStore(): MemberStore {
         return MemberPersistence(database, coroutineDispatchers)

--- a/domains/store/src/main/kotlin/app/dapk/st/domain/application/eventlog/EventLogPersistence.kt
+++ b/domains/store/src/main/kotlin/app/dapk/st/domain/application/eventlog/EventLogPersistence.kt
@@ -1,4 +1,4 @@
-package app.dapk.st.domain.eventlog
+package app.dapk.st.domain.application.eventlog
 
 import app.dapk.db.DapkDb
 import app.dapk.st.core.CoroutineDispatchers

--- a/domains/store/src/main/kotlin/app/dapk/st/domain/application/eventlog/LoggingStore.kt
+++ b/domains/store/src/main/kotlin/app/dapk/st/domain/application/eventlog/LoggingStore.kt
@@ -1,4 +1,4 @@
-package app.dapk.st.domain.eventlog
+package app.dapk.st.domain.application.eventlog
 
 import app.dapk.st.core.CachedPreferences
 import app.dapk.st.core.readBoolean

--- a/domains/store/src/main/kotlin/app/dapk/st/domain/application/message/MessageOptionsStore.kt
+++ b/domains/store/src/main/kotlin/app/dapk/st/domain/application/message/MessageOptionsStore.kt
@@ -1,0 +1,17 @@
+package app.dapk.st.domain.application.message
+
+import app.dapk.st.core.CachedPreferences
+import app.dapk.st.core.readBoolean
+import app.dapk.st.core.store
+
+private const val KEY_READ_RECEIPTS_DISABLED = "key_read_receipts_disabled"
+
+class MessageOptionsStore(private val cachedPreferences: CachedPreferences) {
+
+    suspend fun isReadReceiptsDisabled() = cachedPreferences.readBoolean(KEY_READ_RECEIPTS_DISABLED, defaultValue = true)
+
+    suspend fun setReadReceiptsDisabled(isDisabled: Boolean) {
+        cachedPreferences.store(KEY_READ_RECEIPTS_DISABLED, isDisabled)
+    }
+
+}

--- a/domains/store/src/main/kotlin/app/dapk/st/domain/eventlog/EventLogPersistence.kt
+++ b/domains/store/src/main/kotlin/app/dapk/st/domain/eventlog/EventLogPersistence.kt
@@ -1,8 +1,8 @@
 package app.dapk.st.domain.eventlog
 
+import app.dapk.db.DapkDb
 import app.dapk.st.core.CoroutineDispatchers
 import app.dapk.st.core.withIoContext
-import app.dapk.db.DapkDb
 import com.squareup.sqldelight.runtime.coroutines.asFlow
 import com.squareup.sqldelight.runtime.coroutines.mapToList
 import kotlinx.coroutines.flow.Flow
@@ -42,6 +42,7 @@ class EventLogPersistence(
                         )
                     }
                 }
+
             else -> database.eventLoggerQueries.selectLatestByLogFiltered(logKey, filter)
                 .asFlow()
                 .mapToList(context = coroutineDispatchers.io)

--- a/domains/store/src/main/kotlin/app/dapk/st/domain/eventlog/LoggingStore.kt
+++ b/domains/store/src/main/kotlin/app/dapk/st/domain/eventlog/LoggingStore.kt
@@ -1,0 +1,17 @@
+package app.dapk.st.domain.eventlog
+
+import app.dapk.st.core.CachedPreferences
+import app.dapk.st.core.readBoolean
+import app.dapk.st.core.store
+
+private const val KEY_LOGGING_ENABLED = "key_logging_enabled"
+
+class LoggingStore(private val cachedPreferences: CachedPreferences) {
+
+    suspend fun isEnabled() = cachedPreferences.readBoolean(KEY_LOGGING_ENABLED, defaultValue = false)
+
+    suspend fun setEnabled(isEnabled: Boolean) {
+        cachedPreferences.store(KEY_LOGGING_ENABLED, isEnabled)
+    }
+
+}

--- a/domains/store/src/main/kotlin/app/dapk/st/domain/preference/CachingPreferences.kt
+++ b/domains/store/src/main/kotlin/app/dapk/st/domain/preference/CachingPreferences.kt
@@ -1,0 +1,26 @@
+package app.dapk.st.domain.preference
+
+import app.dapk.st.core.CachedPreferences
+import app.dapk.st.core.Preferences
+
+class CachingPreferences(private val cache: PropertyCache, private val preferences: Preferences) : CachedPreferences {
+
+    override suspend fun store(key: String, value: String) {
+        cache.setValue(key, value)
+        preferences.store(key, value)
+    }
+
+    override suspend fun readString(key: String): String? {
+        return cache.getValue(key) ?: preferences.readString(key)?.also {
+            cache.setValue(key, it)
+        }
+    }
+
+    override suspend fun remove(key: String) {
+        preferences.remove(key)
+    }
+
+    override suspend fun clear() {
+        preferences.clear()
+    }
+}

--- a/domains/store/src/main/kotlin/app/dapk/st/domain/preference/CachingPreferences.kt
+++ b/domains/store/src/main/kotlin/app/dapk/st/domain/preference/CachingPreferences.kt
@@ -4,7 +4,6 @@ import app.dapk.st.core.CachedPreferences
 import app.dapk.st.core.Preferences
 
 class CachingPreferences(private val cache: PropertyCache, private val preferences: Preferences) : CachedPreferences {
-
     override suspend fun store(key: String, value: String) {
         cache.setValue(key, value)
         preferences.store(key, value)
@@ -14,6 +13,10 @@ class CachingPreferences(private val cache: PropertyCache, private val preferenc
         return cache.getValue(key) ?: preferences.readString(key)?.also {
             cache.setValue(key, it)
         }
+    }
+
+    override suspend fun readString(key: String, defaultValue: String): String {
+        return readString(key) ?: (defaultValue.also { cache.setValue(key, it) })
     }
 
     override suspend fun remove(key: String) {

--- a/domains/store/src/main/kotlin/app/dapk/st/domain/preference/PropertyCache.kt
+++ b/domains/store/src/main/kotlin/app/dapk/st/domain/preference/PropertyCache.kt
@@ -1,0 +1,16 @@
+package app.dapk.st.domain.preference
+
+@Suppress("UNCHECKED_CAST")
+class PropertyCache {
+
+    private val map = mutableMapOf<String, Any>()
+
+    fun <T> getValue(key: String): T? {
+        return map[key] as? T?
+    }
+
+    fun setValue(key: String, value: Any) {
+        map[key] = value
+    }
+
+}

--- a/domains/store/src/testFixtures/kotlin/fake/FakeLoggingStore.kt
+++ b/domains/store/src/testFixtures/kotlin/fake/FakeLoggingStore.kt
@@ -1,6 +1,6 @@
-package app.dapk.st.settings
+package fake
 
-import app.dapk.st.domain.eventlog.LoggingStore
+import app.dapk.st.domain.application.eventlog.LoggingStore
 import io.mockk.coEvery
 import io.mockk.mockk
 import test.delegateReturn

--- a/domains/store/src/testFixtures/kotlin/fake/FakeMessageOptionsStore.kt
+++ b/domains/store/src/testFixtures/kotlin/fake/FakeMessageOptionsStore.kt
@@ -1,0 +1,12 @@
+package fake
+
+import app.dapk.st.domain.application.message.MessageOptionsStore
+import io.mockk.coEvery
+import io.mockk.mockk
+import test.delegateReturn
+
+class FakeMessageOptionsStore {
+    val instance = mockk<MessageOptionsStore>()
+
+    fun givenReadReceiptsDisabled() = coEvery { instance.isReadReceiptsDisabled() }.delegateReturn()
+}

--- a/domains/store/src/testFixtures/kotlin/fake/FakeStoreCleaner.kt
+++ b/domains/store/src/testFixtures/kotlin/fake/FakeStoreCleaner.kt
@@ -1,4 +1,4 @@
-package fixture
+package fake
 
 import app.dapk.st.domain.StoreCleaner
 import io.mockk.mockk

--- a/features/messenger/build.gradle
+++ b/features/messenger/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     implementation project(":matrix:services:room")
     implementation project(":domains:android:compose-core")
     implementation project(":domains:android:viewmodel")
+    implementation project(":domains:store")
     implementation project(":core")
     implementation project(":features:navigator")
     implementation project(":design-library")

--- a/features/messenger/src/main/kotlin/app/dapk/st/messenger/MessengerModule.kt
+++ b/features/messenger/src/main/kotlin/app/dapk/st/messenger/MessengerModule.kt
@@ -3,6 +3,7 @@ package app.dapk.st.messenger
 import android.content.Context
 import app.dapk.st.core.Base64
 import app.dapk.st.core.ProvidableModule
+import app.dapk.st.domain.application.message.MessageOptionsStore
 import app.dapk.st.matrix.common.CredentialsStore
 import app.dapk.st.matrix.common.RoomId
 import app.dapk.st.matrix.message.MessageService
@@ -22,10 +23,21 @@ class MessengerModule(
     private val context: Context,
     private val base64: Base64,
     private val imageMetaReader: ImageContentReader,
+    private val messageOptionsStore: MessageOptionsStore,
 ) : ProvidableModule {
 
     internal fun messengerViewModel(): MessengerViewModel {
-        return MessengerViewModel(messageService, roomService, roomStore, credentialsStore, timelineUseCase(), LocalIdFactory(), imageMetaReader, clock)
+        return MessengerViewModel(
+            messageService,
+            roomService,
+            roomStore,
+            credentialsStore,
+            timelineUseCase(),
+            LocalIdFactory(),
+            imageMetaReader,
+            messageOptionsStore,
+            clock
+        )
     }
 
     private fun timelineUseCase(): TimelineUseCaseImpl {

--- a/features/messenger/src/main/kotlin/app/dapk/st/messenger/MessengerViewModel.kt
+++ b/features/messenger/src/main/kotlin/app/dapk/st/messenger/MessengerViewModel.kt
@@ -101,7 +101,7 @@ internal class MessengerViewModel(
     private fun CoroutineScope.updateRoomReadStateAsync(latestReadEvent: EventId, state: MessengerState): Deferred<Unit> {
         return async {
             runCatching {
-                roomService.markFullyRead(state.roomState.roomOverview.roomId, latestReadEvent)
+                roomService.markFullyRead(state.roomState.roomOverview.roomId, latestReadEvent, isPrivate = true)
                 roomStore.markRead(state.roomState.roomOverview.roomId)
             }
         }

--- a/features/messenger/src/main/kotlin/app/dapk/st/messenger/MessengerViewModel.kt
+++ b/features/messenger/src/main/kotlin/app/dapk/st/messenger/MessengerViewModel.kt
@@ -3,6 +3,7 @@ package app.dapk.st.messenger
 import androidx.lifecycle.viewModelScope
 import app.dapk.st.core.Lce
 import app.dapk.st.core.extensions.takeIfContent
+import app.dapk.st.domain.application.message.MessageOptionsStore
 import app.dapk.st.matrix.common.CredentialsStore
 import app.dapk.st.matrix.common.EventId
 import app.dapk.st.matrix.common.RoomId
@@ -30,6 +31,7 @@ internal class MessengerViewModel(
     private val observeTimeline: ObserveTimelineUseCase,
     private val localIdFactory: LocalIdFactory,
     private val imageContentReader: ImageContentReader,
+    private val messageOptionsStore: MessageOptionsStore,
     private val clock: Clock,
     factory: MutableStateFactory<MessengerScreenState> = defaultStateFactory(),
 ) : DapkViewModel<MessengerScreenState, MessengerEvent>(
@@ -101,7 +103,7 @@ internal class MessengerViewModel(
     private fun CoroutineScope.updateRoomReadStateAsync(latestReadEvent: EventId, state: MessengerState): Deferred<Unit> {
         return async {
             runCatching {
-                roomService.markFullyRead(state.roomState.roomOverview.roomId, latestReadEvent, isPrivate = true)
+                roomService.markFullyRead(state.roomState.roomOverview.roomId, latestReadEvent, isPrivate = messageOptionsStore.isReadReceiptsDisabled())
                 roomStore.markRead(state.roomState.roomOverview.roomId)
             }
         }

--- a/features/messenger/src/test/kotlin/app/dapk/st/messenger/MessengerViewModelTest.kt
+++ b/features/messenger/src/test/kotlin/app/dapk/st/messenger/MessengerViewModelTest.kt
@@ -69,7 +69,7 @@ class MessengerViewModelTest {
     @Test
     fun `given timeline emits state, when starting, then updates state and marks room and events as read`() = runViewModelTest {
         fakeRoomStore.expectUnit(times = 2) { it.markRead(A_ROOM_ID) }
-        fakeRoomService.expectUnit { it.markFullyRead(A_ROOM_ID, AN_EVENT_ID) }
+        fakeRoomService.expectUnit { it.markFullyRead(A_ROOM_ID, AN_EVENT_ID, isPrivate = true) }
         val state = aMessengerStateWithEvent(AN_EVENT_ID, A_SELF_ID)
         fakeObserveTimelineUseCase.given(A_ROOM_ID, A_SELF_ID).returns(flowOf(state))
 

--- a/features/settings/src/main/kotlin/app/dapk/st/settings/SettingsItemFactory.kt
+++ b/features/settings/src/main/kotlin/app/dapk/st/settings/SettingsItemFactory.kt
@@ -1,6 +1,10 @@
 package app.dapk.st.settings
 
-import app.dapk.st.core.*
+import app.dapk.st.core.BuildMeta
+import app.dapk.st.core.DeviceMeta
+import app.dapk.st.core.ThemeStore
+import app.dapk.st.core.isAtLeastS
+import app.dapk.st.domain.eventlog.LoggingStore
 import app.dapk.st.push.PushTokenRegistrars
 
 internal class SettingsItemFactory(
@@ -8,14 +12,14 @@ internal class SettingsItemFactory(
     private val deviceMeta: DeviceMeta,
     private val pushTokenRegistrars: PushTokenRegistrars,
     private val themeStore: ThemeStore,
+    private val loggingStore: LoggingStore,
 ) {
 
-    suspend fun root() = general() + theme() + data() + account() + about()
+    suspend fun root() = general() + theme() + data() + account() + advanced() + about()
 
     private suspend fun general() = listOf(
         SettingItem.Header("General"),
         SettingItem.Text(SettingItem.Id.Encryption, "Encryption"),
-        SettingItem.Text(SettingItem.Id.EventLog, "Event log"),
         SettingItem.Text(SettingItem.Id.PushProvider, "Push provider", pushTokenRegistrars.currentSelection().id)
     )
 
@@ -35,6 +39,15 @@ internal class SettingsItemFactory(
         SettingItem.Header("Account"),
         SettingItem.Text(SettingItem.Id.SignOut, "Sign out"),
     )
+
+    private suspend fun advanced(): List<SettingItem> {
+        val loggingIsEnabled = loggingStore.isEnabled()
+        return listOf(
+            SettingItem.Header("Advanced"),
+            SettingItem.Toggle(SettingItem.Id.ToggleEnableLogs, "Enable local logging", state = loggingIsEnabled),
+            SettingItem.Text(SettingItem.Id.EventLog, "Event log", enabled = loggingIsEnabled),
+        )
+    }
 
     private fun about() = listOf(
         SettingItem.Header("About"),

--- a/features/settings/src/main/kotlin/app/dapk/st/settings/SettingsItemFactory.kt
+++ b/features/settings/src/main/kotlin/app/dapk/st/settings/SettingsItemFactory.kt
@@ -4,7 +4,8 @@ import app.dapk.st.core.BuildMeta
 import app.dapk.st.core.DeviceMeta
 import app.dapk.st.core.ThemeStore
 import app.dapk.st.core.isAtLeastS
-import app.dapk.st.domain.eventlog.LoggingStore
+import app.dapk.st.domain.application.eventlog.LoggingStore
+import app.dapk.st.domain.application.message.MessageOptionsStore
 import app.dapk.st.push.PushTokenRegistrars
 
 internal class SettingsItemFactory(
@@ -13,6 +14,7 @@ internal class SettingsItemFactory(
     private val pushTokenRegistrars: PushTokenRegistrars,
     private val themeStore: ThemeStore,
     private val loggingStore: LoggingStore,
+    private val messageOptionsStore: MessageOptionsStore,
 ) {
 
     suspend fun root() = general() + theme() + data() + account() + advanced() + about()
@@ -44,6 +46,12 @@ internal class SettingsItemFactory(
         val loggingIsEnabled = loggingStore.isEnabled()
         return listOf(
             SettingItem.Header("Advanced"),
+            SettingItem.Toggle(
+                SettingItem.Id.ToggleSendReadReceipts,
+                "Don't send message read receipts",
+                subtitle = "Requires the Homeserver to be running Synapse 1.65+",
+                state = messageOptionsStore.isReadReceiptsDisabled()
+            ),
             SettingItem.Toggle(SettingItem.Id.ToggleEnableLogs, "Enable local logging", state = loggingIsEnabled),
             SettingItem.Text(SettingItem.Id.EventLog, "Event log", enabled = loggingIsEnabled),
         )

--- a/features/settings/src/main/kotlin/app/dapk/st/settings/SettingsItemFactory.kt
+++ b/features/settings/src/main/kotlin/app/dapk/st/settings/SettingsItemFactory.kt
@@ -19,7 +19,7 @@ internal class SettingsItemFactory(
         SettingItem.Text(SettingItem.Id.PushProvider, "Push provider", pushTokenRegistrars.currentSelection().id)
     )
 
-    private fun theme() = listOfNotNull(
+    private suspend fun theme() = listOfNotNull(
         SettingItem.Header("Theme"),
         SettingItem.Toggle(SettingItem.Id.ToggleDynamicTheme, "Enable Material You", state = themeStore.isMaterialYouEnabled()).takeIf {
             deviceMeta.isAtLeastS()

--- a/features/settings/src/main/kotlin/app/dapk/st/settings/SettingsModule.kt
+++ b/features/settings/src/main/kotlin/app/dapk/st/settings/SettingsModule.kt
@@ -3,7 +3,8 @@ package app.dapk.st.settings
 import android.content.ContentResolver
 import app.dapk.st.core.*
 import app.dapk.st.domain.StoreModule
-import app.dapk.st.domain.eventlog.LoggingStore
+import app.dapk.st.domain.application.eventlog.LoggingStore
+import app.dapk.st.domain.application.message.MessageOptionsStore
 import app.dapk.st.matrix.crypto.CryptoService
 import app.dapk.st.matrix.sync.SyncService
 import app.dapk.st.push.PushModule
@@ -20,6 +21,7 @@ class SettingsModule(
     private val coroutineDispatchers: CoroutineDispatchers,
     private val themeStore: ThemeStore,
     private val loggingStore: LoggingStore,
+    private val messageOptionsStore: MessageOptionsStore,
 ) : ProvidableModule {
 
     internal fun settingsViewModel(): SettingsViewModel {
@@ -29,10 +31,11 @@ class SettingsModule(
             cryptoService,
             syncService,
             UriFilenameResolver(contentResolver, coroutineDispatchers),
-            SettingsItemFactory(buildMeta, deviceMeta, pushModule.pushTokenRegistrars(), themeStore, loggingStore),
+            SettingsItemFactory(buildMeta, deviceMeta, pushModule.pushTokenRegistrars(), themeStore, loggingStore, messageOptionsStore),
             pushModule.pushTokenRegistrars(),
             themeStore,
             loggingStore,
+            messageOptionsStore,
         )
     }
 

--- a/features/settings/src/main/kotlin/app/dapk/st/settings/SettingsModule.kt
+++ b/features/settings/src/main/kotlin/app/dapk/st/settings/SettingsModule.kt
@@ -3,6 +3,7 @@ package app.dapk.st.settings
 import android.content.ContentResolver
 import app.dapk.st.core.*
 import app.dapk.st.domain.StoreModule
+import app.dapk.st.domain.eventlog.LoggingStore
 import app.dapk.st.matrix.crypto.CryptoService
 import app.dapk.st.matrix.sync.SyncService
 import app.dapk.st.push.PushModule
@@ -18,6 +19,7 @@ class SettingsModule(
     private val deviceMeta: DeviceMeta,
     private val coroutineDispatchers: CoroutineDispatchers,
     private val themeStore: ThemeStore,
+    private val loggingStore: LoggingStore,
 ) : ProvidableModule {
 
     internal fun settingsViewModel(): SettingsViewModel {
@@ -27,9 +29,10 @@ class SettingsModule(
             cryptoService,
             syncService,
             UriFilenameResolver(contentResolver, coroutineDispatchers),
-            SettingsItemFactory(buildMeta, deviceMeta, pushModule.pushTokenRegistrars(), themeStore),
+            SettingsItemFactory(buildMeta, deviceMeta, pushModule.pushTokenRegistrars(), themeStore, loggingStore),
             pushModule.pushTokenRegistrars(),
             themeStore,
+            loggingStore,
         )
     }
 

--- a/features/settings/src/main/kotlin/app/dapk/st/settings/SettingsScreen.kt
+++ b/features/settings/src/main/kotlin/app/dapk/st/settings/SettingsScreen.kt
@@ -5,7 +5,6 @@ import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
 import android.widget.Toast
-import androidx.activity.compose.LocalActivityResultRegistryOwner
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.clickable
@@ -197,11 +196,11 @@ private fun RootSettings(page: Page.Root, onClick: (SettingItem) -> Unit) {
                 items(content.value) { item ->
                     when (item) {
                         is SettingItem.Text -> {
-                            val itemOnClick = onClick.takeIf { item.id != SettingItem.Id.Ignored }?.let {
-                                { it.invoke(item) }
-                            }
+                            val itemOnClick = onClick.takeIf {
+                                item.id != SettingItem.Id.Ignored && item.enabled
+                            }?.let { { it.invoke(item) } }
 
-                            SettingsTextRow(item.content, item.subtitle, itemOnClick)
+                            SettingsTextRow(item.content, item.subtitle, itemOnClick, enabled = item.enabled)
                         }
 
                         is SettingItem.AccessToken -> {
@@ -313,6 +312,7 @@ private fun SettingsViewModel.ObserveEvents(onSignOut: () -> Unit) {
                 is OpenUrl -> {
                     context.startActivity(Intent(Intent.ACTION_VIEW).apply { data = it.url.toUri() })
                 }
+
                 RecreateActivity -> {
                     context.getActivity()?.recreate()
                 }

--- a/features/settings/src/main/kotlin/app/dapk/st/settings/SettingsScreen.kt
+++ b/features/settings/src/main/kotlin/app/dapk/st/settings/SettingsScreen.kt
@@ -41,10 +41,7 @@ import app.dapk.st.core.StartObserving
 import app.dapk.st.core.components.CenteredLoading
 import app.dapk.st.core.components.Header
 import app.dapk.st.core.getActivity
-import app.dapk.st.design.components.SettingsTextRow
-import app.dapk.st.design.components.Spider
-import app.dapk.st.design.components.SpiderPage
-import app.dapk.st.design.components.TextRow
+import app.dapk.st.design.components.*
 import app.dapk.st.matrix.crypto.ImportResult
 import app.dapk.st.navigator.Navigator
 import app.dapk.st.settings.SettingsEvent.*
@@ -222,7 +219,7 @@ private fun RootSettings(page: Page.Root, onClick: (SettingItem) -> Unit) {
                         }
 
                         is SettingItem.Header -> Header(item.label)
-                        is SettingItem.Toggle -> Toggle(item, onToggle = {
+                        is SettingItem.Toggle -> SettingsToggleRow(item.content, item.subtitle, item.state, onToggle = {
                             onClick(item)
                         })
                     }
@@ -238,23 +235,6 @@ private fun RootSettings(page: Page.Root, onClick: (SettingItem) -> Unit) {
         is Lce.Loading -> {
             // TODO
         }
-    }
-}
-
-@Composable
-private fun Toggle(item: SettingItem.Toggle, onToggle: () -> Unit) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(start = 24.dp, end = 24.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceBetween
-    ) {
-        Text(text = item.content)
-        Switch(
-            checked = item.state,
-            onCheckedChange = { onToggle() }
-        )
     }
 }
 

--- a/features/settings/src/main/kotlin/app/dapk/st/settings/SettingsState.kt
+++ b/features/settings/src/main/kotlin/app/dapk/st/settings/SettingsState.kt
@@ -44,7 +44,7 @@ internal sealed interface SettingItem {
 
     data class Header(val label: String, override val id: Id = Id.Ignored) : SettingItem
     data class Text(override val id: Id, val content: String, val subtitle: String? = null, val enabled: Boolean = true) : SettingItem
-    data class Toggle(override val id: Id, val content: String, val state: Boolean) : SettingItem
+    data class Toggle(override val id: Id, val content: String, val subtitle: String? = null, val state: Boolean) : SettingItem
     data class AccessToken(override val id: Id, val content: String, val accessToken: String) : SettingItem
 
     enum class Id {
@@ -58,6 +58,7 @@ internal sealed interface SettingItem {
         Ignored,
         ToggleDynamicTheme,
         ToggleEnableLogs,
+        ToggleSendReadReceipts,
     }
 }
 

--- a/features/settings/src/main/kotlin/app/dapk/st/settings/SettingsState.kt
+++ b/features/settings/src/main/kotlin/app/dapk/st/settings/SettingsState.kt
@@ -43,7 +43,7 @@ internal sealed interface SettingItem {
     val id: Id
 
     data class Header(val label: String, override val id: Id = Id.Ignored) : SettingItem
-    data class Text(override val id: Id, val content: String, val subtitle: String? = null) : SettingItem
+    data class Text(override val id: Id, val content: String, val subtitle: String? = null, val enabled: Boolean = true) : SettingItem
     data class Toggle(override val id: Id, val content: String, val state: Boolean) : SettingItem
     data class AccessToken(override val id: Id, val content: String, val accessToken: String) : SettingItem
 
@@ -57,6 +57,7 @@ internal sealed interface SettingItem {
         PrivacyPolicy,
         Ignored,
         ToggleDynamicTheme,
+        ToggleEnableLogs,
     }
 }
 

--- a/features/settings/src/main/kotlin/app/dapk/st/settings/SettingsViewModel.kt
+++ b/features/settings/src/main/kotlin/app/dapk/st/settings/SettingsViewModel.kt
@@ -7,6 +7,7 @@ import app.dapk.st.core.Lce
 import app.dapk.st.core.ThemeStore
 import app.dapk.st.design.components.SpiderPage
 import app.dapk.st.domain.StoreCleaner
+import app.dapk.st.domain.eventlog.LoggingStore
 import app.dapk.st.matrix.crypto.CryptoService
 import app.dapk.st.matrix.crypto.ImportResult
 import app.dapk.st.matrix.sync.SyncService
@@ -32,6 +33,7 @@ internal class SettingsViewModel(
     private val settingsItemFactory: SettingsItemFactory,
     private val pushTokenRegistrars: PushTokenRegistrars,
     private val themeStore: ThemeStore,
+    private val loggingStore: LoggingStore,
     factory: MutableStateFactory<SettingsScreenState> = defaultStateFactory(),
 ) : DapkViewModel<SettingsScreenState, SettingsEvent>(
     initialState = SettingsScreenState(SpiderPage(Page.Routes.root, "Settings", null, Page.Root(Lce.Loading()))),
@@ -52,31 +54,23 @@ internal class SettingsViewModel(
 
     fun onClick(item: SettingItem) {
         when (item.id) {
-            SignOut -> {
-                viewModelScope.launch {
-                    cacheCleaner.cleanCache(removeCredentials = true)
-                    _events.emit(SignedOut)
-                }
+            SignOut -> viewModelScope.launch {
+                cacheCleaner.cleanCache(removeCredentials = true)
+                _events.emit(SignedOut)
             }
 
-            AccessToken -> {
-                viewModelScope.launch {
-                    require(item is SettingItem.AccessToken)
-                    _events.emit(CopyToClipboard("Token copied", item.accessToken))
-                }
+            AccessToken -> viewModelScope.launch {
+                require(item is SettingItem.AccessToken)
+                _events.emit(CopyToClipboard("Token copied", item.accessToken))
             }
 
-            ClearCache -> {
-                viewModelScope.launch {
-                    cacheCleaner.cleanCache(removeCredentials = false)
-                    _events.emit(Toast(message = "Cache deleted"))
-                }
+            ClearCache -> viewModelScope.launch {
+                cacheCleaner.cleanCache(removeCredentials = false)
+                _events.emit(Toast(message = "Cache deleted"))
             }
 
-            EventLog -> {
-                viewModelScope.launch {
-                    _events.emit(OpenEventLog)
-                }
+            EventLog -> viewModelScope.launch {
+                _events.emit(OpenEventLog)
             }
 
             Encryption -> {
@@ -85,10 +79,8 @@ internal class SettingsViewModel(
                 }
             }
 
-            PrivacyPolicy -> {
-                viewModelScope.launch {
-                    _events.emit(OpenUrl(PRIVACY_POLICY_URL))
-                }
+            PrivacyPolicy -> viewModelScope.launch {
+                _events.emit(OpenUrl(PRIVACY_POLICY_URL))
             }
 
             PushProvider -> {
@@ -100,16 +92,24 @@ internal class SettingsViewModel(
             Ignored -> {
                 // do nothing
             }
-            ToggleDynamicTheme -> {
-                viewModelScope.launch {
-                    themeStore.storeMaterialYouEnabled(!themeStore.isMaterialYouEnabled())
-                    start()
-                    _events.emit(RecreateActivity)
-                }
+
+            ToggleDynamicTheme -> viewModelScope.launch {
+                themeStore.storeMaterialYouEnabled(!themeStore.isMaterialYouEnabled())
+                refreshRoot()
+                _events.emit(RecreateActivity)
+
+            }
+
+            ToggleEnableLogs -> viewModelScope.launch {
+                loggingStore.setEnabled(!loggingStore.isEnabled())
+                refreshRoot()
             }
         }
     }
 
+    private fun refreshRoot() {
+        start()
+    }
 
     fun fetchPushProviders() {
         updatePageState<Page.PushProviders> { copy(options = Lce.Loading()) }
@@ -146,9 +146,11 @@ internal class SettingsViewModel(
                                         is ImportResult.Error -> {
                                             // do nothing
                                         }
+
                                         is ImportResult.Update -> {
                                             // do nothing
                                         }
+
                                         is ImportResult.Success -> {
                                             syncService.forceManualRefresh(it.roomIds.toList())
                                         }

--- a/features/settings/src/main/kotlin/app/dapk/st/settings/SettingsViewModel.kt
+++ b/features/settings/src/main/kotlin/app/dapk/st/settings/SettingsViewModel.kt
@@ -109,6 +109,7 @@ internal class SettingsViewModel(
 
             ToggleSendReadReceipts -> viewModelScope.launch {
                 messageOptionsStore.setReadReceiptsDisabled(!messageOptionsStore.isReadReceiptsDisabled())
+                refreshRoot()
             }
         }
     }

--- a/features/settings/src/main/kotlin/app/dapk/st/settings/SettingsViewModel.kt
+++ b/features/settings/src/main/kotlin/app/dapk/st/settings/SettingsViewModel.kt
@@ -7,7 +7,8 @@ import app.dapk.st.core.Lce
 import app.dapk.st.core.ThemeStore
 import app.dapk.st.design.components.SpiderPage
 import app.dapk.st.domain.StoreCleaner
-import app.dapk.st.domain.eventlog.LoggingStore
+import app.dapk.st.domain.application.eventlog.LoggingStore
+import app.dapk.st.domain.application.message.MessageOptionsStore
 import app.dapk.st.matrix.crypto.CryptoService
 import app.dapk.st.matrix.crypto.ImportResult
 import app.dapk.st.matrix.sync.SyncService
@@ -34,6 +35,7 @@ internal class SettingsViewModel(
     private val pushTokenRegistrars: PushTokenRegistrars,
     private val themeStore: ThemeStore,
     private val loggingStore: LoggingStore,
+    private val messageOptionsStore: MessageOptionsStore,
     factory: MutableStateFactory<SettingsScreenState> = defaultStateFactory(),
 ) : DapkViewModel<SettingsScreenState, SettingsEvent>(
     initialState = SettingsScreenState(SpiderPage(Page.Routes.root, "Settings", null, Page.Root(Lce.Loading()))),
@@ -103,6 +105,10 @@ internal class SettingsViewModel(
             ToggleEnableLogs -> viewModelScope.launch {
                 loggingStore.setEnabled(!loggingStore.isEnabled())
                 refreshRoot()
+            }
+
+            ToggleSendReadReceipts -> viewModelScope.launch {
+                messageOptionsStore.setReadReceiptsDisabled(!messageOptionsStore.isReadReceiptsDisabled())
             }
         }
     }

--- a/features/settings/src/main/kotlin/app/dapk/st/settings/eventlogger/EventLoggerState.kt
+++ b/features/settings/src/main/kotlin/app/dapk/st/settings/eventlogger/EventLoggerState.kt
@@ -1,7 +1,7 @@
 package app.dapk.st.settings.eventlogger
 
 import app.dapk.st.core.Lce
-import app.dapk.st.domain.eventlog.LogLine
+import app.dapk.st.domain.application.eventlog.LogLine
 
 data class EventLoggerState(
     val logs: Lce<List<String>>,

--- a/features/settings/src/main/kotlin/app/dapk/st/settings/eventlogger/EventLoggerViewModel.kt
+++ b/features/settings/src/main/kotlin/app/dapk/st/settings/eventlogger/EventLoggerViewModel.kt
@@ -2,7 +2,7 @@ package app.dapk.st.settings.eventlogger
 
 import androidx.lifecycle.viewModelScope
 import app.dapk.st.core.Lce
-import app.dapk.st.domain.eventlog.EventLogPersistence
+import app.dapk.st.domain.application.eventlog.EventLogPersistence
 import app.dapk.st.viewmodel.DapkViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.collect

--- a/features/settings/src/test/kotlin/app/dapk/st/settings/FakeLoggingStore.kt
+++ b/features/settings/src/test/kotlin/app/dapk/st/settings/FakeLoggingStore.kt
@@ -1,0 +1,12 @@
+package app.dapk.st.settings
+
+import app.dapk.st.domain.eventlog.LoggingStore
+import io.mockk.coEvery
+import io.mockk.mockk
+import test.delegateReturn
+
+class FakeLoggingStore {
+    val instance = mockk<LoggingStore>()
+
+    fun givenLoggingIsEnabled() = coEvery { instance.isEnabled() }.delegateReturn()
+}

--- a/features/settings/src/test/kotlin/app/dapk/st/settings/FakeThemeStore.kt
+++ b/features/settings/src/test/kotlin/app/dapk/st/settings/FakeThemeStore.kt
@@ -1,6 +1,7 @@
 package app.dapk.st.settings
 
 import app.dapk.st.core.ThemeStore
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import test.delegateReturn
@@ -8,5 +9,5 @@ import test.delegateReturn
 class FakeThemeStore {
     val instance = mockk<ThemeStore>()
 
-    fun givenMaterialYouIsEnabled() = every { instance.isMaterialYouEnabled() }.delegateReturn()
+    fun givenMaterialYouIsEnabled() = coEvery { instance.isMaterialYouEnabled() }.delegateReturn()
 }

--- a/features/settings/src/test/kotlin/app/dapk/st/settings/SettingsItemFactoryTest.kt
+++ b/features/settings/src/test/kotlin/app/dapk/st/settings/SettingsItemFactoryTest.kt
@@ -15,6 +15,7 @@ import test.delegateReturn
 
 private val A_SELECTION = Registrar("A_SELECTION")
 private const val ENABLED_MATERIAL_YOU = true
+private const val DISABLED_LOGGING = false
 
 class SettingsItemFactoryTest {
 
@@ -22,20 +23,27 @@ class SettingsItemFactoryTest {
     private val deviceMeta = DeviceMeta(apiVersion = 31)
     private val fakePushTokenRegistrars = FakePushRegistrars()
     private val fakeThemeStore = FakeThemeStore()
+    private val fakeLoggingStore = FakeLoggingStore()
 
-    private val settingsItemFactory = SettingsItemFactory(buildMeta, deviceMeta, fakePushTokenRegistrars.instance, fakeThemeStore.instance)
+    private val settingsItemFactory = SettingsItemFactory(
+        buildMeta,
+        deviceMeta,
+        fakePushTokenRegistrars.instance,
+        fakeThemeStore.instance,
+        fakeLoggingStore.instance
+    )
 
     @Test
     fun `when creating root items, then is expected`() = runTest {
         fakePushTokenRegistrars.givenCurrentSelection().returns(A_SELECTION)
         fakeThemeStore.givenMaterialYouIsEnabled().returns(ENABLED_MATERIAL_YOU)
+        fakeLoggingStore.givenLoggingIsEnabled().returns(DISABLED_LOGGING)
 
         val result = settingsItemFactory.root()
 
         result shouldBeEqualTo listOf(
             aSettingHeaderItem("General"),
             aSettingTextItem(SettingItem.Id.Encryption, "Encryption"),
-            aSettingTextItem(SettingItem.Id.EventLog, "Event log"),
             aSettingTextItem(SettingItem.Id.PushProvider, "Push provider", A_SELECTION.id),
             SettingItem.Header("Theme"),
             SettingItem.Toggle(SettingItem.Id.ToggleDynamicTheme, "Enable Material You", state = ENABLED_MATERIAL_YOU),
@@ -43,6 +51,9 @@ class SettingsItemFactoryTest {
             aSettingTextItem(SettingItem.Id.ClearCache, "Clear cache"),
             aSettingHeaderItem("Account"),
             aSettingTextItem(SettingItem.Id.SignOut, "Sign out"),
+            aSettingHeaderItem("Advanced"),
+            SettingItem.Toggle(SettingItem.Id.ToggleEnableLogs, "Enable local logging", state = DISABLED_LOGGING),
+            aSettingTextItem(SettingItem.Id.EventLog, "Event log", enabled = DISABLED_LOGGING),
             aSettingHeaderItem("About"),
             aSettingTextItem(SettingItem.Id.PrivacyPolicy, "Privacy policy"),
             aSettingTextItem(SettingItem.Id.Ignored, "Version", buildMeta.versionName),

--- a/features/settings/src/test/kotlin/app/dapk/st/settings/SettingsItemFactoryTest.kt
+++ b/features/settings/src/test/kotlin/app/dapk/st/settings/SettingsItemFactoryTest.kt
@@ -4,6 +4,8 @@ import app.dapk.st.core.BuildMeta
 import app.dapk.st.core.DeviceMeta
 import app.dapk.st.push.PushTokenRegistrars
 import app.dapk.st.push.Registrar
+import fake.FakeLoggingStore
+import fake.FakeMessageOptionsStore
 import internalfixture.aSettingHeaderItem
 import internalfixture.aSettingTextItem
 import io.mockk.coEvery
@@ -16,6 +18,7 @@ import test.delegateReturn
 private val A_SELECTION = Registrar("A_SELECTION")
 private const val ENABLED_MATERIAL_YOU = true
 private const val DISABLED_LOGGING = false
+private const val DISABLED_READ_RECEIPTS = true
 
 class SettingsItemFactoryTest {
 
@@ -24,13 +27,15 @@ class SettingsItemFactoryTest {
     private val fakePushTokenRegistrars = FakePushRegistrars()
     private val fakeThemeStore = FakeThemeStore()
     private val fakeLoggingStore = FakeLoggingStore()
+    private val fakeMessageOptionsStore = FakeMessageOptionsStore()
 
     private val settingsItemFactory = SettingsItemFactory(
         buildMeta,
         deviceMeta,
         fakePushTokenRegistrars.instance,
         fakeThemeStore.instance,
-        fakeLoggingStore.instance
+        fakeLoggingStore.instance,
+        fakeMessageOptionsStore.instance,
     )
 
     @Test
@@ -38,6 +43,7 @@ class SettingsItemFactoryTest {
         fakePushTokenRegistrars.givenCurrentSelection().returns(A_SELECTION)
         fakeThemeStore.givenMaterialYouIsEnabled().returns(ENABLED_MATERIAL_YOU)
         fakeLoggingStore.givenLoggingIsEnabled().returns(DISABLED_LOGGING)
+        fakeMessageOptionsStore.givenReadReceiptsDisabled().returns(DISABLED_READ_RECEIPTS)
 
         val result = settingsItemFactory.root()
 
@@ -52,6 +58,12 @@ class SettingsItemFactoryTest {
             aSettingHeaderItem("Account"),
             aSettingTextItem(SettingItem.Id.SignOut, "Sign out"),
             aSettingHeaderItem("Advanced"),
+            SettingItem.Toggle(
+                SettingItem.Id.ToggleSendReadReceipts,
+                "Don't send message read receipts",
+                subtitle = "Requires the Homeserver to be running Synapse 1.65+",
+                state = DISABLED_READ_RECEIPTS
+            ),
             SettingItem.Toggle(SettingItem.Id.ToggleEnableLogs, "Enable local logging", state = DISABLED_LOGGING),
             aSettingTextItem(SettingItem.Id.EventLog, "Event log", enabled = DISABLED_LOGGING),
             aSettingHeaderItem("About"),

--- a/features/settings/src/test/kotlin/app/dapk/st/settings/SettingsViewModelTest.kt
+++ b/features/settings/src/test/kotlin/app/dapk/st/settings/SettingsViewModelTest.kt
@@ -41,6 +41,7 @@ internal class SettingsViewModelTest {
     private val fakePushTokenRegistrars = FakePushRegistrars()
     private val fakeSettingsItemFactory = FakeSettingsItemFactory()
     private val fakeThemeStore = FakeThemeStore()
+    private val fakeLoggingStore = FakeLoggingStore()
 
     private val viewModel = SettingsViewModel(
         fakeStoreCleaner,
@@ -51,6 +52,7 @@ internal class SettingsViewModelTest {
         fakeSettingsItemFactory.instance,
         fakePushTokenRegistrars.instance,
         fakeThemeStore.instance,
+        fakeLoggingStore.instance,
         runViewModelTest.testMutableStateFactory(),
     )
 

--- a/features/settings/src/test/kotlin/app/dapk/st/settings/SettingsViewModelTest.kt
+++ b/features/settings/src/test/kotlin/app/dapk/st/settings/SettingsViewModelTest.kt
@@ -5,7 +5,7 @@ import app.dapk.st.core.Lce
 import app.dapk.st.design.components.SpiderPage
 import app.dapk.st.matrix.crypto.ImportResult
 import fake.*
-import fixture.FakeStoreCleaner
+import fake.FakeStoreCleaner
 import fixture.aRoomId
 import internalfake.FakeSettingsItemFactory
 import internalfake.FakeUriFilenameResolver
@@ -42,6 +42,7 @@ internal class SettingsViewModelTest {
     private val fakeSettingsItemFactory = FakeSettingsItemFactory()
     private val fakeThemeStore = FakeThemeStore()
     private val fakeLoggingStore = FakeLoggingStore()
+    private val fakeMessageOptionsStore = FakeMessageOptionsStore()
 
     private val viewModel = SettingsViewModel(
         fakeStoreCleaner,
@@ -53,6 +54,7 @@ internal class SettingsViewModelTest {
         fakePushTokenRegistrars.instance,
         fakeThemeStore.instance,
         fakeLoggingStore.instance,
+        fakeMessageOptionsStore.instance,
         runViewModelTest.testMutableStateFactory(),
     )
 

--- a/features/settings/src/test/kotlin/internalfixture/SettingItemFixture.kt
+++ b/features/settings/src/test/kotlin/internalfixture/SettingItemFixture.kt
@@ -5,8 +5,9 @@ import app.dapk.st.settings.SettingItem
 internal fun aSettingTextItem(
     id: SettingItem.Id = SettingItem.Id.Ignored,
     content: String = "text-content",
-    subtitle: String? = null
-) = SettingItem.Text(id, content, subtitle)
+    subtitle: String? = null,
+    enabled: Boolean = true,
+) = SettingItem.Text(id, content, subtitle, enabled)
 
 internal fun aSettingHeaderItem(
     label: String = "header-label",

--- a/matrix/services/room/src/main/kotlin/app/dapk/st/matrix/room/RoomService.kt
+++ b/matrix/services/room/src/main/kotlin/app/dapk/st/matrix/room/RoomService.kt
@@ -15,7 +15,7 @@ private val SERVICE_KEY = RoomService::class
 interface RoomService : MatrixService {
 
     suspend fun joinedMembers(roomId: RoomId): List<JoinedMember>
-    suspend fun markFullyRead(roomId: RoomId, eventId: EventId)
+    suspend fun markFullyRead(roomId: RoomId, eventId: EventId, isPrivate: Boolean)
 
     suspend fun findMember(roomId: RoomId, userId: UserId): RoomMember?
     suspend fun findMembers(roomId: RoomId, userIds: List<UserId>): List<RoomMember>

--- a/matrix/services/room/src/main/kotlin/app/dapk/st/matrix/room/internal/DefaultRoomService.kt
+++ b/matrix/services/room/src/main/kotlin/app/dapk/st/matrix/room/internal/DefaultRoomService.kt
@@ -30,9 +30,9 @@ class DefaultRoomService(
         }
     }
 
-    override suspend fun markFullyRead(roomId: RoomId, eventId: EventId) {
+    override suspend fun markFullyRead(roomId: RoomId, eventId: EventId, isPrivate: Boolean) {
         logger.matrixLog(ROOM, "marking room fully read ${roomId.value}")
-        httpClient.execute(markFullyReadRequest(roomId, eventId))
+        httpClient.execute(markFullyReadRequest(roomId, eventId, isPrivate))
     }
 
     override suspend fun findMember(roomId: RoomId, userId: UserId): RoomMember? {
@@ -97,10 +97,10 @@ internal fun joinedMembersRequest(roomId: RoomId) = httpRequest<JoinedMembersRes
     method = MatrixHttpClient.Method.GET,
 )
 
-internal fun markFullyReadRequest(roomId: RoomId, eventId: EventId) = httpRequest<Unit>(
+internal fun markFullyReadRequest(roomId: RoomId, eventId: EventId, isPrivate: Boolean) = httpRequest<Unit>(
     path = "_matrix/client/r0/rooms/${roomId.value}/read_markers",
     method = MatrixHttpClient.Method.POST,
-    body = jsonBody(MarkFullyReadRequest(eventId, eventId, hidden = true))
+    body = jsonBody(MarkFullyReadRequest(eventId, eventId, hidden = isPrivate))
 )
 
 internal fun createRoomRequest(invites: List<UserId>, isDM: Boolean, visibility: RoomVisibility, name: String? = null) = httpRequest<ApiCreateRoomResponse>(


### PR DESCRIPTION
Adds extra settings options

- Enable/Disable on device logging - now disabled by default for new installs
- Disable/Enabled sending read receipts - disabled by default (toggle is enabled) 

| SCREENSHOT |
| --- |
![Screenshot_20221008_120907](https://user-images.githubusercontent.com/1848238/194704472-9f3b7492-d166-4298-b0d7-95b1c7510488.png)
