### PR TITLE
Fix Android 13 being unable to launch attachment picker

### DIFF
--- a/features/messenger/src/main/kotlin/app/dapk/st/messenger/gallery/ImageGalleryActivity.kt
+++ b/features/messenger/src/main/kotlin/app/dapk/st/messenger/gallery/ImageGalleryActivity.kt
@@ -5,6 +5,7 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import android.os.Parcelable
 import androidx.activity.result.contract.ActivityResultContract
@@ -32,7 +33,7 @@ class ImageGalleryActivity : DapkActivity() {
         val permissionState = mutableStateOf<Lce<PermissionResult>>(Lce.Loading())
 
         lifecycleScope.launch {
-            permissionState.value = runCatching { ensurePermission(Manifest.permission.READ_EXTERNAL_STORAGE) }.fold(
+            permissionState.value = runCatching { ensurePermission(mediaPermission()) }.fold(
                 onSuccess = { Lce.Content(it) },
                 onFailure = { Lce.Error(it) }
             )
@@ -48,6 +49,12 @@ class ImageGalleryActivity : DapkActivity() {
                 }
             }
         }
+    }
+
+    private fun mediaPermission() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        Manifest.permission.READ_MEDIA_IMAGES
+    } else {
+        Manifest.permission.READ_EXTERNAL_STORAGE
     }
 }
 


### PR DESCRIPTION
- Android 13 requires the `read_media_images` permission instead of read external

| BEFORE | AFTER | 
| --- | --- |
|![before-13-attachment](https://user-images.githubusercontent.com/1848238/195452681-7cd1c5d8-1de4-4dda-82e2-ed702a30712c.gif)|![after-13-attachment](https://user-images.githubusercontent.com/1848238/195452662-cdc79b6c-8a8e-4398-9c27-e3cdc334ef75.gif)

