### PR TITLE
Fixes login sometimes never transitioning to next state

### DIFF
--- a/features/home/src/main/kotlin/app/dapk/st/home/HomeViewModel.kt
+++ b/features/home/src/main/kotlin/app/dapk/st/home/HomeViewModel.kt
@@ -122,6 +122,6 @@ class HomeViewModel(
     }
 
     fun stop() {
-        viewModelScope.cancel()
+        // do nothing
     }
 }


### PR DESCRIPTION
The ViewModelScope was being cancelled with the Composable lifecycle which put the ViewModel in an invalid state which ignored future interactions, causing an infinite spinner 

| BEFORE | AFTER |
| --- | --- |
|![before-login](https://user-images.githubusercontent.com/1848238/196288188-f7d24f66-a966-4a24-afb8-b1960000223a.gif)|![after-login](https://user-images.githubusercontent.com/1848238/196288203-65d8dbe2-5169-46a7-a694-071a7892e5c8.gif)


