### PR TITLE
Fix dendrite failing to fully login

### DIFF
--- a/matrix/services/sync/src/main/kotlin/app/dapk/st/matrix/sync/internal/request/ApiSyncResponse.kt
+++ b/matrix/services/sync/src/main/kotlin/app/dapk/st/matrix/sync/internal/request/ApiSyncResponse.kt
@@ -13,7 +13,7 @@ internal data class ApiSyncResponse(
     @SerialName("account_data") val accountData: ApiAccountData? = null,
     @SerialName("rooms") val rooms: ApiSyncRooms? = null,
     @SerialName("to_device") val toDevice: ToDevice? = null,
-    @SerialName("device_one_time_keys_count") val oneTimeKeysCount: Map<String, ServerKeyCount>,
+    @SerialName("device_one_time_keys_count") val oneTimeKeysCount: Map<String, ServerKeyCount>? = null,
     @SerialName("next_batch") val nextBatch: SyncToken,
     @SerialName("prev_batch") val prevBatch: SyncToken? = null,
 )

--- a/matrix/services/sync/src/main/kotlin/app/dapk/st/matrix/sync/internal/room/SyncSideEffects.kt
+++ b/matrix/services/sync/src/main/kotlin/app/dapk/st/matrix/sync/internal/room/SyncSideEffects.kt
@@ -28,7 +28,7 @@ internal class SyncSideEffects(
                 notifyDevicesUpdated.notifyChanges(it, requestToken)
             }
 
-            oneTimeKeyProducer.onServerKeyCount(response.oneTimeKeysCount["signed_curve25519"] ?: ServerKeyCount(0))
+            oneTimeKeyProducer.onServerKeyCount(response.oneTimeKeysCount?.get("signed_curve25519") ?: ServerKeyCount(0))
 
             val decryptedToDeviceEvents = decryptedToDeviceEvents(response)
             val roomKeys = handleRoomKeyShares(decryptedToDeviceEvents)


### PR DESCRIPTION
- for dendrite the field is provided in later syncs
- 
| ST PROFILE | ST CHAT | ELEMENT CHAT |
| --- | --- | --- |
![Screenshot_20221022_191305](https://user-images.githubusercontent.com/1848238/197356409-918aa7ae-feed-4100-ae58-c67d16cc0d0a.png)|![Screenshot_20221022_191336](https://user-images.githubusercontent.com/1848238/197356408-dd1503cc-a84d-471f-879b-62ea1ff96eca.png)|![2022-10-22T19:14:11,907131247+01:00](https://user-images.githubusercontent.com/1848238/197356407-0cb1a55b-ccbc-4759-9b9a-fc3e6250422c.png)