### PR TITLE
Allow SyncResponse state events to be optional

### DIFF
--- a/matrix/services/sync/src/main/kotlin/app/dapk/st/matrix/sync/internal/request/ApiSyncResponse.kt
+++ b/matrix/services/sync/src/main/kotlin/app/dapk/st/matrix/sync/internal/request/ApiSyncResponse.kt
@@ -53,7 +53,7 @@ internal data class ApiInviteEvents(
 @Serializable
 internal data class ApiSyncRoom(
     @SerialName("timeline") val timeline: ApiSyncRoomTimeline,
-    @SerialName("state") val state: ApiSyncRoomState,
+    @SerialName("state") val state: ApiSyncRoomState? = null,
     @SerialName("account_data") val accountData: ApiAccountData? = null,
     @SerialName("ephemeral") val ephemeral: ApiEphemeral? = null,
     @SerialName("summary") val summary: ApiRoomSummary? = null,

--- a/matrix/services/sync/src/main/kotlin/app/dapk/st/matrix/sync/internal/sync/RoomOverviewProcessor.kt
+++ b/matrix/services/sync/src/main/kotlin/app/dapk/st/matrix/sync/internal/sync/RoomOverviewProcessor.kt
@@ -13,7 +13,7 @@ internal class RoomOverviewProcessor(
 ) {
 
     suspend fun process(roomToProcess: RoomToProcess, previousState: RoomOverview?, lastMessage: LastMessage?): RoomOverview? {
-        val combinedEvents = roomToProcess.apiSyncRoom.state.stateEvents + roomToProcess.apiSyncRoom.timeline.apiTimelineEvents
+        val combinedEvents = (roomToProcess.apiSyncRoom.state?.stateEvents.orEmpty()) + roomToProcess.apiSyncRoom.timeline.apiTimelineEvents
         val isEncrypted = combinedEvents.any { it is ApiTimelineEvent.Encryption }
         val readMarker = roomToProcess.apiSyncRoom.accountData?.events?.filterIsInstance<ApiAccountEvent.FullyRead>()?.firstOrNull()?.content?.eventId
         return when (previousState) {

--- a/matrix/services/sync/src/main/kotlin/app/dapk/st/matrix/sync/internal/sync/RoomProcessor.kt
+++ b/matrix/services/sync/src/main/kotlin/app/dapk/st/matrix/sync/internal/sync/RoomProcessor.kt
@@ -50,7 +50,7 @@ internal class RoomProcessor(
 }
 
 private fun ApiSyncRoom.collectMembers(userCredentials: UserCredentials): List<RoomMember> {
-    return (this.state.stateEvents + this.timeline.apiTimelineEvents)
+    return (this.state?.stateEvents.orEmpty() + this.timeline.apiTimelineEvents)
         .filterIsInstance<ApiTimelineEvent.RoomMember>()
         .mapNotNull {
             when {

--- a/matrix/services/sync/src/main/kotlin/app/dapk/st/matrix/sync/internal/sync/SyncReducer.kt
+++ b/matrix/services/sync/src/main/kotlin/app/dapk/st/matrix/sync/internal/sync/SyncReducer.kt
@@ -70,7 +70,7 @@ internal class SyncReducer(
     }
 
     private fun findRoomsLeft(response: ApiSyncResponse, userCredentials: UserCredentials) = response.rooms?.leave?.filter {
-        it.value.state.stateEvents.filterIsInstance<ApiTimelineEvent.RoomMember>().any {
+        it.value.state?.stateEvents.orEmpty().filterIsInstance<ApiTimelineEvent.RoomMember>().any {
             it.content.membership.isLeave() && it.senderId == userCredentials.userId
         }
     }?.map { it.key } ?: emptyList()
@@ -91,7 +91,7 @@ internal class SyncReducer(
 }
 
 private fun Map<RoomId, ApiSyncRoom>.keepRoomsWithChanges() = this.filter {
-    it.value.state.stateEvents.isNotEmpty() ||
+    it.value.state?.stateEvents.orEmpty().isNotEmpty() ||
             it.value.timeline.apiTimelineEvents.isNotEmpty() ||
             it.value.accountData?.events?.isNotEmpty() == true ||
             it.value.ephemeral?.events?.isNotEmpty() == true


### PR DESCRIPTION
- dendrite can omit the state field from the sync response

```
19:53:34.590  W  Caused by: kotlinx.serialization.MissingFieldException: Field 'state' is required for type with serial name 'app.dapk.st.matrix.sync.internal.request.ApiSyncRoom', but it was missing
19:53:34.591  W  	at kotlinx.serialization.internal.PluginExceptionsKt.throwMissingFieldException(PluginExceptions.kt:20)
19:53:34.591  W  	at app.dapk.st.matrix.sync.internal.request.ApiSyncRoom.<init>(ApiSyncResponse.kt:53)
19:53:34.591  W  	at app.dapk.st.matrix.sync.internal.request.ApiSyncRoom$$serializer.deserialize(ApiSyncResponse.kt:53)
19:53:34.591  W  	at app.dapk.st.matrix.sync.internal.request.ApiSyncRoom$$serializer.deserialize(ApiSyncResponse.kt:53)
19:53:34.591  W  	at kotlinx.serialization.json.internal.StreamingJsonDecoder.decodeSerializableValue(StreamingJsonDecoder.kt:70)
19:53:34.591  W  	... 65 more
```