### PR TITLE
Fix edits changing message order

### DIFF
--- a/matrix/services/sync/src/main/kotlin/app/dapk/st/matrix/sync/internal/sync/RoomEventCreator.kt
+++ b/matrix/services/sync/src/main/kotlin/app/dapk/st/matrix/sync/internal/sync/RoomEventCreator.kt
@@ -152,7 +152,6 @@ internal class TimelineEventMapper(
 
     private fun RoomEvent.Message.edited(edit: ApiTimelineEvent.TimelineMessage) = this.copy(
         content = richMessageParser.parse(edit.asTextContent().let { it.formattedBody ?: it.body }?.removePrefix(" * ") ?: "redacted"),
-        utcTimestamp = edit.utcTimestamp,
         edited = true,
     )
 

--- a/matrix/services/sync/src/test/kotlin/app/dapk/st/matrix/sync/internal/sync/RoomEventCreatorTest.kt
+++ b/matrix/services/sync/src/test/kotlin/app/dapk/st/matrix/sync/internal/sync/RoomEventCreatorTest.kt
@@ -146,7 +146,7 @@ internal class RoomEventCreatorTest {
 
         result shouldBeEqualTo aMatrixRoomMessageEvent(
             eventId = originalMessage.eventId,
-            utcTimestamp = editedMessage.utcTimestamp,
+            utcTimestamp = originalMessage.utcTimestamp,
             content = A_TEXT_EVENT_MESSAGE,
             author = A_SENDER,
             edited = true
@@ -166,7 +166,7 @@ internal class RoomEventCreatorTest {
             replyingTo = originalMessage.replyingTo,
             message = aMatrixRoomMessageEvent(
                 eventId = originalMessage.eventId,
-                utcTimestamp = editedMessage.utcTimestamp,
+                utcTimestamp = originalMessage.utcTimestamp,
                 content = A_TEXT_EVENT_MESSAGE,
                 author = A_SENDER,
                 edited = true


### PR DESCRIPTION
- was caused by the edited event timestamp replacing the original message, which in turn caused the message to be ordered as the latest message

*gif edits the `1` message

| BEFORE | AFTER |
| --- | --- |
|![before-edit-event](https://user-images.githubusercontent.com/1848238/199797497-485b693e-ecd1-4832-8cf7-4e1d9d6e979a.gif)|![after-edit-event](https://user-images.githubusercontent.com/1848238/199797492-ea7ee83a-c5a9-4159-a3b6-838bce36e03b.gif)
