### PR TITLE
Fix app upgrade not asking user to clear cache

### DIFF
--- a/features/home/src/main/kotlin/app/dapk/st/home/BetaVersionUpgradeUseCase.kt
+++ b/features/home/src/main/kotlin/app/dapk/st/home/BetaVersionUpgradeUseCase.kt
@@ -25,8 +25,6 @@ class BetaVersionUpgradeUseCase(
         return when (previousVersion) {
             null -> false
             else -> currentVersion > previousVersion
-        }.also {
-            applicationPreferences.setVersion(ApplicationVersion(currentVersion))
         }
     }
 
@@ -38,7 +36,8 @@ class BetaVersionUpgradeUseCase(
         }
     }
 
-    fun notifyUpgraded() {
+    suspend fun notifyUpgraded() {
+        applicationPreferences.setVersion(ApplicationVersion(buildMeta.versionCode))
         _continuation?.resume(Unit)
         _continuation = null
     }


### PR DESCRIPTION
the app was incorrectly reading the current version, causing the _clear cache on upgrade flow_ to be skipped