### PR TITLE
Tech/sync error logging

### DIFF
--- a/domains/android/tracking/src/main/kotlin/app/dapk/st/tracking/CrashTrackerLogger.kt
+++ b/domains/android/tracking/src/main/kotlin/app/dapk/st/tracking/CrashTrackerLogger.kt
@@ -10,6 +10,19 @@ class CrashTrackerLogger : ErrorTracker {
     override fun track(throwable: Throwable, extra: String) {
         Log.e("ST", throwable.message, throwable)
         log(AppLogTag.ERROR_NON_FATAL, "${throwable.message ?: "N/A"} extra=$extra")
+
+        throwable.findCauseMessage()?.let {
+            if (throwable.message != it) {
+                log(AppLogTag.ERROR_NON_FATAL, it)
+            }
+        }
+    }
+}
+
+private fun Throwable.findCauseMessage(): String? {
+    return when (val inner = this.cause) {
+        null -> this.message ?: ""
+        else -> inner.findCauseMessage()
     }
 }
 

--- a/features/home/src/main/kotlin/app/dapk/st/home/HomeViewModel.kt
+++ b/features/home/src/main/kotlin/app/dapk/st/home/HomeViewModel.kt
@@ -15,7 +15,6 @@ import app.dapk.st.profile.state.ProfileState
 import app.dapk.st.viewmodel.DapkViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -58,11 +57,10 @@ internal class HomeViewModel(
 
     private suspend fun initialHomeContent(): SignedIn {
         val me = chatEngine.me(forceRefresh = false)
-        val initialInvites = chatEngine.invites().first().size
         return when (val current = state) {
-            Loading -> SignedIn(Page.Directory, me, invites = initialInvites)
-            is SignedIn -> current.copy(me = me, invites = initialInvites)
-            SignedOut -> SignedIn(Page.Directory, me, invites = initialInvites)
+            Loading -> SignedIn(Page.Directory, me, invites = 0)
+            is SignedIn -> current.copy(me = me, invites = current.invites)
+            SignedOut -> SignedIn(Page.Directory, me, invites = 0)
         }
     }
 

--- a/features/settings/src/main/kotlin/app/dapk/st/settings/eventlogger/EventLogScreen.kt
+++ b/features/settings/src/main/kotlin/app/dapk/st/settings/eventlogger/EventLogScreen.kt
@@ -107,10 +107,10 @@ private fun Events(selectedPageContent: SelectedState, onExit: () -> Unit, onSel
                             null -> "${it.time}: ${it.tag}: ${it.content}"
                             else -> "${it.time}: ${it.content}"
                         }
-
                         Text(
                             text = text,
-                            modifier = Modifier.padding(horizontal = 4.dp),
+                            lineHeight = 14.sp,
+                            modifier = Modifier.padding(horizontal = 4.dp).fillMaxWidth(),
                             fontSize = 10.sp,
                         )
                     }

--- a/matrix/services/sync/src/main/kotlin/app/dapk/st/matrix/sync/internal/DefaultSyncService.kt
+++ b/matrix/services/sync/src/main/kotlin/app/dapk/st/matrix/sync/internal/DefaultSyncService.kt
@@ -76,7 +76,7 @@ internal class DefaultSyncService(
         )
         SyncUseCase(
             overviewStore,
-            SideEffectFlowIterator(logger),
+            SideEffectFlowIterator(logger, errorTracker),
             SyncSideEffects(keySharer, verificationHandler, deviceNotifier, messageDecrypter, json, oneTimeKeyProducer, logger),
             httpClient,
             syncStore,

--- a/matrix/services/sync/src/main/kotlin/app/dapk/st/matrix/sync/internal/FlowIterator.kt
+++ b/matrix/services/sync/src/main/kotlin/app/dapk/st/matrix/sync/internal/FlowIterator.kt
@@ -1,12 +1,13 @@
 package app.dapk.st.matrix.sync.internal
 
+import app.dapk.st.core.extensions.ErrorTracker
 import app.dapk.st.matrix.common.MatrixLogTag.SYNC
 import app.dapk.st.matrix.common.MatrixLogger
 import app.dapk.st.matrix.common.matrixLog
 import kotlinx.coroutines.*
 
-internal class SideEffectFlowIterator(private val logger: MatrixLogger) {
-    suspend fun <T> loop(initial: T?, onPost: suspend () -> Unit, onIteration: suspend (T?) -> T?) {
+internal class SideEffectFlowIterator(private val logger: MatrixLogger, private val errorTracker: ErrorTracker) {
+    suspend fun <T> loop(initial: T?, onPost: suspend (Throwable?) -> Unit, onIteration: suspend (T?) -> T?) {
         var previousState = initial
 
         while (currentCoroutineContext().isActive) {
@@ -15,11 +16,12 @@ internal class SideEffectFlowIterator(private val logger: MatrixLogger) {
                 previousState = withContext(NonCancellable) {
                     onIteration(previousState)
                 }
-                onPost()
+                onPost(null)
             } catch (error: Throwable) {
                 logger.matrixLog(SYNC, "on loop error: ${error.message}")
-                error.printStackTrace()
+                errorTracker.track(error, "sync loop error")
                 delay(10000L)
+                onPost(error)
             }
         }
         logger.matrixLog(SYNC, "isActive: ${currentCoroutineContext().isActive}")


### PR DESCRIPTION
- Including sync errors into the event log and crashlytics tracking (if the build has it included)
- Allows the Messages screen to load an empty view when the sync fails (which in turn allows the logs to be enabled and checked)

*Forcing the sync response parsing to fail 

| | 
| --- | 
![Screenshot_20221110_231439](https://user-images.githubusercontent.com/1848238/201225692-0407c36e-cc19-477a-8519-4f16ee09b241.png)|
