### PR TITLE
Allow messages `up arrow` to relaunch main screen

### DIFF
--- a/features/home/src/main/AndroidManifest.xml
+++ b/features/home/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application>
-        <activity android:name="app.dapk.st.home.MainActivity"/>
+        <activity android:name="app.dapk.st.home.MainActivity" android:launchMode="singleInstance"/>
     </application>
 
 </manifest>

--- a/features/navigator/src/main/kotlin/app/dapk/st/navigator/Navigator.kt
+++ b/features/navigator/src/main/kotlin/app/dapk/st/navigator/Navigator.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Parcel
 import android.os.Parcelable
+import androidx.core.app.NavUtils
 import app.dapk.st.core.AndroidUri
 import app.dapk.st.core.MimeType
 import app.dapk.st.matrix.common.RoomId
@@ -33,7 +34,8 @@ interface Navigator {
         }
 
         fun upToHome() {
-            activity.navigateUpTo(intentFactory.home(activity))
+            activity.finish()
+            activity.startActivity(intentFactory.home(activity))
         }
 
         fun toMessenger(roomId: RoomId, attachments: List<MessageAttachment>) {


### PR DESCRIPTION
- The `navigateUpTo` does not work when the app is not already running in the background
- Replaces with a manual navigation to the main screen and ensures only 1 instance can be launched

Fixes https://github.com/ouchadam/small-talk/issues/269

| BEFORE | AFTER | 
| --- | --- |
|![before-up-arrow](https://user-images.githubusercontent.com/1848238/211158621-41ad97f1-2f8b-4096-bd5e-a494f9f91f40.gif)|![after-up-arrow](https://user-images.githubusercontent.com/1848238/211158619-56ae1fac-7e98-4d40-b0c2-353cd0ca3853.gif)
