### PR TITLE
Crash fix when sending message after replying to an unsupported message type

### DIFF
--- a/features/messenger/src/main/kotlin/app/dapk/st/messenger/state/MessengerReducer.kt
+++ b/features/messenger/src/main/kotlin/app/dapk/st/messenger/state/MessengerReducer.kt
@@ -85,12 +85,22 @@ internal fun messengerReducer(
 
         change(ComposerStateChange.ReplyMode::class) { action, state ->
             when (action) {
-                is ComposerStateChange.ReplyMode.Enter -> state.copy(
-                    composerState = when (state.composerState) {
-                        is ComposerState.Attachments -> state.composerState.copy(reply = action.replyingTo)
-                        is ComposerState.Text -> state.composerState.copy(reply = action.replyingTo)
+                is ComposerStateChange.ReplyMode.Enter -> {
+                    when (action.replyingTo) {
+                        is RoomEvent.Message -> state.copy(
+                            composerState = when (state.composerState) {
+                                is ComposerState.Attachments -> state.composerState.copy(reply = action.replyingTo)
+                                is ComposerState.Text -> state.composerState.copy(reply = action.replyingTo)
+                            }
+                        )
+
+                        // TODO support replying to more message types
+                        is RoomEvent.Encrypted,
+                        is RoomEvent.Image,
+                        is RoomEvent.Redacted,
+                        is RoomEvent.Reply -> state
                     }
-                )
+                }
 
                 ComposerStateChange.ReplyMode.Exit -> state.copy(
                     composerState = when (state.composerState) {


### PR DESCRIPTION
Fixes a crash when sending a message after attempting to reply to an unsupported message type

| BEFORE | AFTER |
| --- | --- |
|![before-reply-type](https://user-images.githubusercontent.com/1848238/211159352-0e7276b0-1e6b-41fc-8696-d44a2107d21e.gif)|![after-reply-type](https://user-images.githubusercontent.com/1848238/211159347-ea894613-ae9f-4b1d-b51e-ed8c0886cb68.gif)
