### PR TITLE
Fix missing icon on shortcut entries

### DIFF
--- a/app/src/main/kotlin/app/dapk/st/graph/AppModule.kt
+++ b/app/src/main/kotlin/app/dapk/st/graph/AppModule.kt
@@ -165,6 +165,7 @@ internal class FeatureModules internal constructor(
         DirectoryModule(
             context = context,
             chatEngine = chatEngineModule.engine,
+            iconLoader = imageLoaderModule.iconLoader(),
         )
     }
     val loginModule by unsafeLazy {

--- a/core/src/testFixtures/kotlin/test/ExpectTestScope.kt
+++ b/core/src/testFixtures/kotlin/test/ExpectTestScope.kt
@@ -20,7 +20,7 @@ class ExpectTest(override val coroutineContext: CoroutineContext) : ExpectTestSc
 
     override fun verifyExpects() {
         expects.forEach { (times, block) -> coVerify(exactly = times) { block.invoke(this) } }
-        groups.forEach { coVerifyOrder { it.invoke(this) } }
+        groups.forEach { coVerifyAll { it.invoke(this) } }
     }
 
     override fun <T> T.expectUnit(times: Int, block: suspend MockKMatcherScope.(T) -> Unit) {

--- a/domains/android/core/build.gradle
+++ b/domains/android/core/build.gradle
@@ -4,5 +4,6 @@ plugins {
 
 dependencies {
     compileOnly project(":domains:android:stub")
+    compileOnly libs.androidx.annotation
     implementation project(":core")
 }

--- a/domains/android/core/src/main/kotlin/app/dapk/st/core/DeviceMetaExtensions.kt
+++ b/domains/android/core/src/main/kotlin/app/dapk/st/core/DeviceMetaExtensions.kt
@@ -16,6 +16,11 @@ fun DeviceMeta.onAtLeastO(block: () -> Unit) {
     whenXOrHigher(Build.VERSION_CODES.O, block, fallback = {})
 }
 
+@ChecksSdkIntAtLeast(api = Build.VERSION_CODES.Q, lambda = 0)
+fun DeviceMeta.onAtLeastQ(block: () -> Unit) {
+    whenXOrHigher(Build.VERSION_CODES.Q, block, fallback = {})
+}
+
 @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.R, lambda = 0)
 fun DeviceMeta.onAtLeastR(block: () -> Unit) {
     whenXOrHigher(Build.VERSION_CODES.R, block, fallback = {})

--- a/domains/android/core/src/main/kotlin/app/dapk/st/core/DeviceMetaExtensions.kt
+++ b/domains/android/core/src/main/kotlin/app/dapk/st/core/DeviceMetaExtensions.kt
@@ -1,20 +1,30 @@
 package app.dapk.st.core
 
 import android.os.Build
+import androidx.annotation.ChecksSdkIntAtLeast
 
+@ChecksSdkIntAtLeast(api = Build.VERSION_CODES.O, lambda = 0)
 fun <T> DeviceMeta.isAtLeastO(block: () -> T, fallback: () -> T = { throw IllegalStateException("not handled") }): T {
     return if (this.apiVersion >= Build.VERSION_CODES.O) block() else fallback()
 }
 
+@ChecksSdkIntAtLeast(api = Build.VERSION_CODES.S)
 fun DeviceMeta.isAtLeastS() = this.apiVersion >= Build.VERSION_CODES.S
 
+@ChecksSdkIntAtLeast(api = Build.VERSION_CODES.O, lambda = 0)
 fun DeviceMeta.onAtLeastO(block: () -> Unit) {
-    if (this.apiVersion >= Build.VERSION_CODES.O) block()
+    whenXOrHigher(Build.VERSION_CODES.O, block, fallback = {})
+}
+
+@ChecksSdkIntAtLeast(api = Build.VERSION_CODES.R, lambda = 0)
+fun DeviceMeta.onAtLeastR(block: () -> Unit) {
+    whenXOrHigher(Build.VERSION_CODES.R, block, fallback = {})
 }
 
 inline fun <T> DeviceMeta.whenPOrHigher(block: () -> T, fallback: () -> T) = whenXOrHigher(Build.VERSION_CODES.P, block, fallback)
 inline fun <T> DeviceMeta.whenOOrHigher(block: () -> T, fallback: () -> T) = whenXOrHigher(Build.VERSION_CODES.O, block, fallback)
 
+@ChecksSdkIntAtLeast(parameter = 0, lambda = 1)
 inline fun <T> DeviceMeta.whenXOrHigher(version: Int, block: () -> T, fallback: () -> T): T {
     return if (this.apiVersion >= version) block() else fallback()
 }

--- a/domains/android/stub/src/testFixtures/kotlin/fake/FakeNotificationBuilder.kt
+++ b/domains/android/stub/src/testFixtures/kotlin/fake/FakeNotificationBuilder.kt
@@ -1,8 +1,12 @@
 package fake
 
 import android.app.Notification
+import io.mockk.every
 import io.mockk.mockk
+import test.delegateReturn
 
 class FakeNotificationBuilder {
     val instance = mockk<Notification.Builder>(relaxed = true)
+
+    fun givenBuilds() = every { instance.build() }.delegateReturn()
 }

--- a/features/directory/build.gradle
+++ b/features/directory/build.gradle
@@ -8,6 +8,7 @@ android {
 
 dependencies {
     implementation project(":domains:android:compose-core")
+    implementation project(":domains:android:imageloader")
     implementation "chat-engine:chat-engine"
     implementation 'screen-state:screen-android'
     implementation project(":features:messenger")

--- a/features/directory/src/main/kotlin/app/dapk/st/directory/DirectoryModule.kt
+++ b/features/directory/src/main/kotlin/app/dapk/st/directory/DirectoryModule.kt
@@ -4,19 +4,17 @@ import android.content.Context
 import app.dapk.st.core.JobBag
 import app.dapk.st.core.ProvidableModule
 import app.dapk.st.directory.state.DirectoryEvent
-import app.dapk.st.directory.state.DirectoryState
 import app.dapk.st.directory.state.directoryReducer
 import app.dapk.st.engine.ChatEngine
-import app.dapk.st.state.createStateViewModel
+import app.dapk.st.imageloader.IconLoader
 
 class DirectoryModule(
     private val context: Context,
     private val chatEngine: ChatEngine,
+    private val iconLoader: IconLoader,
 ) : ProvidableModule {
 
-    fun directoryState(): DirectoryState {
-        return createStateViewModel { directoryReducer(it) }
-    }
+    fun directoryReducer(eventEmitter: suspend (DirectoryEvent) -> Unit) = directoryReducer(chatEngine, shortcutHandler(), JobBag(), eventEmitter)
 
-    fun directoryReducer(eventEmitter: suspend (DirectoryEvent) -> Unit) = directoryReducer(chatEngine, ShortcutHandler(context), JobBag(), eventEmitter)
+    private fun shortcutHandler() = ShortcutHandler(context, iconLoader)
 }

--- a/features/messenger/src/main/kotlin/app/dapk/st/messenger/MessengerActivity.kt
+++ b/features/messenger/src/main/kotlin/app/dapk/st/messenger/MessengerActivity.kt
@@ -3,6 +3,7 @@ package app.dapk.st.messenger
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
+import android.content.LocusId
 import android.os.Bundle
 import android.os.Parcelable
 import androidx.compose.foundation.layout.fillMaxSize
@@ -10,11 +11,8 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
-import app.dapk.st.core.AndroidUri
-import app.dapk.st.core.DapkActivity
-import app.dapk.st.core.MimeType
+import app.dapk.st.core.*
 import app.dapk.st.core.extensions.unsafeLazy
-import app.dapk.st.core.module
 import app.dapk.st.matrix.common.RoomId
 import app.dapk.st.messenger.gallery.GetImageFromGallery
 import app.dapk.st.messenger.state.ComposerStateChange
@@ -57,6 +55,8 @@ class MessengerActivity : DapkActivity() {
         super.onCreate(savedInstanceState)
         val payload = readPayload<MessagerActivityPayload>()
         val factory = ImageRequest.Builder(applicationContext).fetcherFactory(module.decryptingFetcherFactory(RoomId(payload.roomId)))
+
+        module.deviceMeta.onAtLeastR { setLocusContext(LocusId(payload.roomId), savedInstanceState) }
 
         val galleryLauncher = registerForActivityResult(GetImageFromGallery()) {
             it?.let { uri ->

--- a/features/messenger/src/main/kotlin/app/dapk/st/messenger/MessengerModule.kt
+++ b/features/messenger/src/main/kotlin/app/dapk/st/messenger/MessengerModule.kt
@@ -16,7 +16,7 @@ class MessengerModule(
     private val chatEngine: ChatEngine,
     private val context: Context,
     private val messageOptionsStore: MessageOptionsStore,
-    private val deviceMeta: DeviceMeta,
+    val deviceMeta: DeviceMeta,
 ) : ProvidableModule {
 
     internal fun messengerState(launchPayload: MessagerActivityPayload): MessengerState {

--- a/features/notifications/src/main/kotlin/app/dapk/st/notifications/AndroidNotificationBuilder.kt
+++ b/features/notifications/src/main/kotlin/app/dapk/st/notifications/AndroidNotificationBuilder.kt
@@ -9,9 +9,9 @@ import android.graphics.drawable.Icon
 import app.dapk.st.core.DeviceMeta
 import app.dapk.st.core.isAtLeastO
 import app.dapk.st.core.onAtLeastO
+import app.dapk.st.core.onAtLeastQ
 
 @SuppressLint("NewApi")
-@Suppress("ObjectPropertyName")
 private val _builderFactory: (Context, String, DeviceMeta) -> Notification.Builder = { context, channel, deviceMeta ->
     deviceMeta.isAtLeastO(
         block = { Notification.Builder(context, channel) },
@@ -23,7 +23,8 @@ class AndroidNotificationBuilder(
     private val context: Context,
     private val deviceMeta: DeviceMeta,
     private val notificationStyleBuilder: AndroidNotificationStyleBuilder,
-    private val builderFactory: (Context, String, DeviceMeta) -> Notification.Builder = _builderFactory
+    private val builderFactory: (Context, String, DeviceMeta) -> Notification.Builder = _builderFactory,
+    private val notificationExtensions: NotificationExtensions = DefaultNotificationExtensions(deviceMeta),
 ) {
     @SuppressLint("NewApi")
     fun build(notification: AndroidNotification): Notification {
@@ -42,7 +43,7 @@ class AndroidNotificationBuilder(
             }
             .ifNotNull(notification.category) { setCategory(it) }
             .ifNotNull(notification.shortcutId) {
-                setLocusId(LocusId(it))
+                with(notificationExtensions) { applyLocusId(it) }
                 deviceMeta.onAtLeastO { setShortcutId(it) }
             }
             .ifNotNull(notification.smallIcon) { setSmallIcon(it) }

--- a/features/notifications/src/main/kotlin/app/dapk/st/notifications/AndroidNotificationBuilder.kt
+++ b/features/notifications/src/main/kotlin/app/dapk/st/notifications/AndroidNotificationBuilder.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.app.Notification
 import android.app.PendingIntent
 import android.content.Context
+import android.content.LocusId
 import android.graphics.drawable.Icon
 import app.dapk.st.core.DeviceMeta
 import app.dapk.st.core.isAtLeastO
@@ -41,7 +42,8 @@ class AndroidNotificationBuilder(
             }
             .ifNotNull(notification.category) { setCategory(it) }
             .ifNotNull(notification.shortcutId) {
-                deviceMeta.onAtLeastO { setShortcutId(notification.shortcutId) }
+                setLocusId(LocusId(it))
+                deviceMeta.onAtLeastO { setShortcutId(it) }
             }
             .ifNotNull(notification.smallIcon) { setSmallIcon(it) }
             .ifNotNull(notification.largeIcon) { setLargeIcon(it) }

--- a/features/notifications/src/main/kotlin/app/dapk/st/notifications/NotificationExtensions.kt
+++ b/features/notifications/src/main/kotlin/app/dapk/st/notifications/NotificationExtensions.kt
@@ -1,0 +1,16 @@
+package app.dapk.st.notifications
+
+import android.app.Notification
+import android.content.LocusId
+import app.dapk.st.core.DeviceMeta
+import app.dapk.st.core.onAtLeastQ
+
+interface NotificationExtensions {
+    fun Notification.Builder.applyLocusId(id: String)
+}
+
+internal class DefaultNotificationExtensions(private val deviceMeta: DeviceMeta) : NotificationExtensions {
+    override fun Notification.Builder.applyLocusId(id: String) {
+        deviceMeta.onAtLeastQ { setLocusId(LocusId(id)) }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ sqldelight = { id = "com.squareup.sqldelight", version.ref = "sqldelight" }
 
 [libraries]
 android-desugar = { group = "com.android.tools", name = "desugar_jdk_libs", version = "1.1.5" }
+androidx-annotation = { group = "androidx.annotation", name = "annotation", version = "1.5.0" }
 
 compose-coil = { group = "io.coil-kt", name = "coil-compose", version = "2.2.2" }
 accompanist-systemuicontroller = { group = "com.google.accompanist", name = "accompanist-systemuicontroller", version = "0.28.0" }


### PR DESCRIPTION
- adds locus id and context to the messages screen
- only shows shorcuts for the most recent rooms with activity (eventually this might want to be customised

| | 
| --- | 
|![Screenshot_20230114_114809](https://user-images.githubusercontent.com/1848238/212470314-9e61d2cc-8f0d-4da8-96e0-5dcf828b3661.png)


